### PR TITLE
Logic: Add commands addProduct, listProduct and removeProduct

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -9,6 +9,7 @@ public class Messages {
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_CONTACT_DISPLAYED_INDEX = "The person index provided is invalid";
     public static final String MESSAGE_INVALID_TEMPLATE_DISPLAYED_INDEX = "The template index provided is invalid";
+    public static final String MESSAGE_INVALID_PRODUCT_DISPLAYED_INDEX = "The product index provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
 
 }

--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -10,6 +10,7 @@ import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.contact.Contact;
 import seedu.address.model.mail.Template;
+import seedu.address.model.products.Product;
 
 /**
  * API of the Logic component
@@ -36,6 +37,9 @@ public interface Logic {
 
     /** Returns an unmodifiable view of the filtered list of templates */
     ObservableList<Template> getFilteredTemplateList();
+
+    /** Returns an unmodifiable view of the filtered list of products */
+    ObservableList<Product> getFilteredProductList();
 
     /**
      * Returns the user prefs' address book file path.

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -16,6 +16,7 @@ import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.contact.Contact;
 import seedu.address.model.mail.Template;
+import seedu.address.model.products.Product;
 import seedu.address.storage.Storage;
 
 /**
@@ -68,6 +69,11 @@ public class LogicManager implements Logic {
     @Override
     public ObservableList<Template> getFilteredTemplateList() {
         return model.getFilteredTemplateList();
+    }
+
+    @Override
+    public ObservableList<Product> getFilteredProductList() {
+        return model.getFilteredProductList();
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/exceptions/CommandException.java
+++ b/src/main/java/seedu/address/logic/commands/exceptions/CommandException.java
@@ -1,5 +1,7 @@
 package seedu.address.logic.commands.exceptions;
 
+import seedu.address.logic.commands.Command;
+
 /**
  * Represents an error which occurs during execution of a {@link Command}.
  */

--- a/src/main/java/seedu/address/logic/commands/products/AddProductCommand.java
+++ b/src/main/java/seedu/address/logic/commands/products/AddProductCommand.java
@@ -1,0 +1,21 @@
+package seedu.address.logic.commands.products;
+
+import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+
+/**
+ * Adds a product to MyCRM.
+ */
+public class AddProductCommand extends Command {
+
+    public static final String COMMAND_WORD = "addProduct";
+
+    public static final String DUMMY_MESSAGE = "Kyaaa Skadi:3";
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        return new CommandResult(DUMMY_MESSAGE);
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/products/AddProductCommand.java
+++ b/src/main/java/seedu/address/logic/commands/products/AddProductCommand.java
@@ -1,5 +1,7 @@
 package seedu.address.logic.commands.products;
 
+import static java.util.Objects.requireNonNull;
+
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -20,20 +22,36 @@ public class AddProductCommand extends Command {
             + "\nNote: Product name cannot be empty."
             + "\nExample: addProduct n/Intel i5-10400F t/CPU m/Intel d/2.90GHz";
 
+    public static final String MESSAGE_SUCCESS = "New product added: %1$s";
+
+    public static final String MESSAGE_DUPLICATE_PRODUCT = "This product already exists in MyCRM";
+
     private final Product toAdd;
 
+    /**
+     * Creates an AddProductCommand.
+     */
     public AddProductCommand(Product product) {
+        requireNonNull(product);
+
         this.toAdd = product;
     }
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
-        return new CommandResult(toAdd.toString());
+        requireNonNull(model);
+
+        if (model.hasProduct(toAdd)) {
+            throw new CommandException(MESSAGE_DUPLICATE_PRODUCT);
+        }
+
+        model.addProduct(toAdd);
+        return new CommandResult(String.format(MESSAGE_SUCCESS, toString()));
     }
 
     @Override
     public String toString() {
-        return "AddProductCommand: " + toAdd;
+        return toAdd.toString();
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/products/AddProductCommand.java
+++ b/src/main/java/seedu/address/logic/commands/products/AddProductCommand.java
@@ -4,6 +4,7 @@ import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
+import seedu.address.model.products.Product;
 
 /**
  * Adds a product to MyCRM.
@@ -12,10 +13,30 @@ public class AddProductCommand extends Command {
 
     public static final String COMMAND_WORD = "addProduct";
 
-    public static final String DUMMY_MESSAGE = "Kyaaa Skadi:3";
+    public static final String MESSAGE_NOT_IMPLEMENTED_YET = "Kyaaa Skadi:3";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Add a new product to the CRM."
+            + "\nParameters: n/NAME [t/TYPE] [m/MANUFACTURER] [d/DESCRIPTION]"
+            + "\nNote: Product name cannot be empty."
+            + "\nExample: addProduct n/Intel i5-10400F t/CPU m/Intel d/2.90GHz";
+
+    private final Product toAdd;
+
+    public AddProductCommand(Product product) {
+        this.toAdd = product;
+    }
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
-        return new CommandResult(DUMMY_MESSAGE);
+        return new CommandResult(toAdd.toString());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o instanceof AddProductCommand) {
+            AddProductCommand cmd = (AddProductCommand) o;
+            return cmd.toAdd.equals(this.toAdd);
+        }
+        return false;
     }
 }

--- a/src/main/java/seedu/address/logic/commands/products/AddProductCommand.java
+++ b/src/main/java/seedu/address/logic/commands/products/AddProductCommand.java
@@ -32,7 +32,20 @@ public class AddProductCommand extends Command {
     }
 
     @Override
+    public String toString() {
+        return "AddProductCommand: " + toAdd;
+    }
+
+    @Override
     public boolean equals(Object o) {
+        if (o == this) {
+            return true;
+        }
+
+        if (o == null) {
+            return false;
+        }
+
         if (o instanceof AddProductCommand) {
             AddProductCommand cmd = (AddProductCommand) o;
             return cmd.toAdd.equals(this.toAdd);

--- a/src/main/java/seedu/address/logic/commands/products/DeleteProductCommand.java
+++ b/src/main/java/seedu/address/logic/commands/products/DeleteProductCommand.java
@@ -1,0 +1,64 @@
+package seedu.address.logic.commands.products;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_PRODUCT_DISPLAYED_INDEX;
+
+import java.util.List;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.products.Product;
+
+public class DeleteProductCommand extends Command {
+
+    public static final String COMMAND_WORD = "deleteProduct";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Deletes the product identified by the index number used in the displayed product list.\n"
+            + "Parameters: INDEX (must be a positive integer)\n"
+            + "Example: " + COMMAND_WORD + " 1";
+
+    public static final String MESSAGE_DELETE_PRODUCT_SUCCESS = "Deleted Product: %1$s";
+
+    private final Index targetIndex;
+
+    /**
+     * Creates a DeleteProductCommand.
+     */
+    public DeleteProductCommand(Index targetIndex) {
+        requireNonNull(targetIndex);
+
+        this.targetIndex = targetIndex;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+
+        List<Product> lastShownList = model.getFilteredProductList();
+
+        if (targetIndex.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(MESSAGE_INVALID_PRODUCT_DISPLAYED_INDEX);
+        }
+
+        Product productToDelete = lastShownList.get(targetIndex.getZeroBased());
+        model.deleteProduct(productToDelete);
+        return new CommandResult(String.format(MESSAGE_DELETE_PRODUCT_SUCCESS, productToDelete));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == this) {
+            return true;
+        }
+
+        if (!(o instanceof DeleteProductCommand)) {
+            return false;
+        }
+
+        return this.targetIndex.equals(((DeleteProductCommand) o).targetIndex);
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/products/ListProductCommand.java
+++ b/src/main/java/seedu/address/logic/commands/products/ListProductCommand.java
@@ -1,0 +1,26 @@
+package seedu.address.logic.commands.products;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PRODUCTS;
+
+import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.model.Model;
+
+/**
+ * Lists all products in MyCrm to the user.
+ */
+public class ListProductCommand extends Command {
+
+    public static final String COMMAND_WORD = "listProduct";
+
+    public static final String MESSAGE_SUCCESS = "Listed all products";
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+
+        model.updateFilteredProductList(PREDICATE_SHOW_ALL_PRODUCTS);
+        return new CommandResult(MESSAGE_SUCCESS);
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -13,6 +13,7 @@ public class CliSyntax {
     public static final Prefix PREFIX_TAG = new Prefix("t/");
 
     public static final Prefix PREFIX_PRODUCT_NAME = new Prefix("n/");
+    public static final Prefix PREFIX_PRODUCT_TYPE = new Prefix("t/");
 
     public static final Prefix PREFIX_SUBJECT = new Prefix("s/");
     public static final Prefix PREFIX_BODY = new Prefix("b/");

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -14,6 +14,7 @@ public class CliSyntax {
 
     public static final Prefix PREFIX_PRODUCT_NAME = new Prefix("n/");
     public static final Prefix PREFIX_PRODUCT_TYPE = new Prefix("t/");
+    public static final Prefix PREFIX_PRODUCT_MANUFACTURER = new Prefix("m/");
 
     public static final Prefix PREFIX_SUBJECT = new Prefix("s/");
     public static final Prefix PREFIX_BODY = new Prefix("b/");

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -12,6 +12,8 @@ public class CliSyntax {
     public static final Prefix PREFIX_ADDRESS = new Prefix("a/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
 
+    public static final Prefix PREFIX_PRODUCT_NAME = new Prefix("n/");
+
     public static final Prefix PREFIX_SUBJECT = new Prefix("s/");
     public static final Prefix PREFIX_BODY = new Prefix("b/");
 }

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -15,6 +15,7 @@ public class CliSyntax {
     public static final Prefix PREFIX_PRODUCT_NAME = new Prefix("n/");
     public static final Prefix PREFIX_PRODUCT_TYPE = new Prefix("t/");
     public static final Prefix PREFIX_PRODUCT_MANUFACTURER = new Prefix("m/");
+    public static final Prefix PREFIX_PRODUCT_DESCRIPTION = new Prefix("d/");
 
     public static final Prefix PREFIX_SUBJECT = new Prefix("s/");
     public static final Prefix PREFIX_BODY = new Prefix("b/");

--- a/src/main/java/seedu/address/logic/parser/MyCrmParser.java
+++ b/src/main/java/seedu/address/logic/parser/MyCrmParser.java
@@ -20,6 +20,8 @@ import seedu.address.logic.commands.mails.AddTemplateCommand;
 import seedu.address.logic.commands.mails.DeleteTemplateCommand;
 import seedu.address.logic.commands.mails.ListTemplateCommand;
 import seedu.address.logic.commands.products.AddProductCommand;
+import seedu.address.logic.commands.products.DeleteProductCommand;
+import seedu.address.logic.commands.products.ListProductCommand;
 import seedu.address.logic.parser.contacts.AddContactCommandParser;
 import seedu.address.logic.parser.contacts.DeleteContactCommandParser;
 import seedu.address.logic.parser.contacts.EditContactCommandParser;
@@ -28,6 +30,7 @@ import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.logic.parser.mails.AddTemplateCommandParser;
 import seedu.address.logic.parser.mails.DeleteTemplateCommandParser;
 import seedu.address.logic.parser.products.AddProductCommandParser;
+import seedu.address.logic.parser.products.DeleteProductCommandParser;
 
 /**
  * Parses user input.
@@ -68,9 +71,6 @@ public class MyCrmParser {
         case ListContactCommand.COMMAND_WORD:
             return new ListContactCommand();
 
-        case AddProductCommand.COMMAND_WORD:
-            return new AddProductCommandParser().parse(arguments);
-
         case ClearCommand.COMMAND_WORD:
             return new ClearCommand();
 
@@ -85,6 +85,15 @@ public class MyCrmParser {
 
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
+
+        case AddProductCommand.COMMAND_WORD:
+            return new AddProductCommandParser().parse(arguments);
+
+        case ListProductCommand.COMMAND_WORD:
+            return new ListProductCommand();
+
+        case DeleteProductCommand.COMMAND_WORD:
+            return new DeleteProductCommandParser().parse(arguments);
 
         case AddTemplateCommand.COMMAND_WORD:
             return new AddTemplateCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/logic/parser/MyCrmParser.java
+++ b/src/main/java/seedu/address/logic/parser/MyCrmParser.java
@@ -27,6 +27,7 @@ import seedu.address.logic.parser.contacts.LinkContactCommandParser;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.logic.parser.mails.AddTemplateCommandParser;
 import seedu.address.logic.parser.mails.DeleteTemplateCommandParser;
+import seedu.address.logic.parser.products.AddProductCommandParser;
 
 /**
  * Parses user input.
@@ -68,7 +69,7 @@ public class MyCrmParser {
             return new ListContactCommand();
 
         case AddProductCommand.COMMAND_WORD:
-            return new AddProductCommand();
+            return new AddProductCommandParser().parse(arguments);
 
         case ClearCommand.COMMAND_WORD:
             return new ClearCommand();

--- a/src/main/java/seedu/address/logic/parser/MyCrmParser.java
+++ b/src/main/java/seedu/address/logic/parser/MyCrmParser.java
@@ -19,6 +19,7 @@ import seedu.address.logic.commands.contacts.ListContactCommand;
 import seedu.address.logic.commands.mails.AddTemplateCommand;
 import seedu.address.logic.commands.mails.DeleteTemplateCommand;
 import seedu.address.logic.commands.mails.ListTemplateCommand;
+import seedu.address.logic.commands.products.AddProductCommand;
 import seedu.address.logic.parser.contacts.AddContactCommandParser;
 import seedu.address.logic.parser.contacts.DeleteContactCommandParser;
 import seedu.address.logic.parser.contacts.EditContactCommandParser;
@@ -65,6 +66,9 @@ public class MyCrmParser {
 
         case ListContactCommand.COMMAND_WORD:
             return new ListContactCommand();
+
+        case AddProductCommand.COMMAND_WORD:
+            return new AddProductCommand();
 
         case ClearCommand.COMMAND_WORD:
             return new ClearCommand();

--- a/src/main/java/seedu/address/logic/parser/products/AddProductCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/products/AddProductCommandParser.java
@@ -2,6 +2,7 @@ package seedu.address.logic.parser.products;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PRODUCT_MANUFACTURER;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PRODUCT_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PRODUCT_TYPE;
 
@@ -12,6 +13,7 @@ import seedu.address.logic.parser.ArgumentMultimap;
 import seedu.address.logic.parser.ArgumentTokenizer;
 import seedu.address.logic.parser.Parser;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.products.Manufacturer;
 import seedu.address.model.products.Product;
 import seedu.address.model.products.Type;
 
@@ -20,7 +22,8 @@ public class AddProductCommandParser implements Parser<AddProductCommand> {
     @Override
     public AddProductCommand parse(String args) throws ParseException {
         requireNonNull(args);
-        ArgumentMultimap argMap = ArgumentTokenizer.tokenize(args, PREFIX_PRODUCT_NAME, PREFIX_PRODUCT_TYPE);
+        ArgumentMultimap argMap = ArgumentTokenizer.tokenize(args, PREFIX_PRODUCT_NAME, PREFIX_PRODUCT_TYPE,
+                PREFIX_PRODUCT_MANUFACTURER);
 
         Optional<String> name = argMap.getValue(PREFIX_PRODUCT_NAME);
         if (name.isEmpty()) {
@@ -36,6 +39,11 @@ public class AddProductCommandParser implements Parser<AddProductCommand> {
                 ? Type.getEmptyType()
                 : Type.getType(typeWrapper.get());
 
-        return new AddProductCommand(new Product(name.get(), type));
+        Optional<String> manufacturerWrapper = argMap.getValue(PREFIX_PRODUCT_MANUFACTURER);
+        Manufacturer manufacturer = manufacturerWrapper.orElse("").equals("")
+                ? Manufacturer.getEmptyManufacturer()
+                : Manufacturer.getManufacturer(manufacturerWrapper.get());
+
+        return new AddProductCommand(new Product(name.get(), type, manufacturer));
     }
 }

--- a/src/main/java/seedu/address/logic/parser/products/AddProductCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/products/AddProductCommandParser.java
@@ -2,6 +2,7 @@ package seedu.address.logic.parser.products;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PRODUCT_DESCRIPTION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PRODUCT_MANUFACTURER;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PRODUCT_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PRODUCT_TYPE;
@@ -13,6 +14,7 @@ import seedu.address.logic.parser.ArgumentMultimap;
 import seedu.address.logic.parser.ArgumentTokenizer;
 import seedu.address.logic.parser.Parser;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.products.Description;
 import seedu.address.model.products.Manufacturer;
 import seedu.address.model.products.Product;
 import seedu.address.model.products.Type;
@@ -23,7 +25,7 @@ public class AddProductCommandParser implements Parser<AddProductCommand> {
     public AddProductCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMap = ArgumentTokenizer.tokenize(args, PREFIX_PRODUCT_NAME, PREFIX_PRODUCT_TYPE,
-                PREFIX_PRODUCT_MANUFACTURER);
+                PREFIX_PRODUCT_MANUFACTURER, PREFIX_PRODUCT_DESCRIPTION);
 
         Optional<String> name = argMap.getValue(PREFIX_PRODUCT_NAME);
         if (name.isEmpty()) {
@@ -44,6 +46,11 @@ public class AddProductCommandParser implements Parser<AddProductCommand> {
                 ? Manufacturer.getEmptyManufacturer()
                 : Manufacturer.getManufacturer(manufacturerWrapper.get());
 
-        return new AddProductCommand(new Product(name.get(), type, manufacturer));
+        Optional<String> descriptionWrapper = argMap.getValue(PREFIX_PRODUCT_DESCRIPTION);
+        Description description = descriptionWrapper.orElse("").equals("")
+                ? Description.getEmptyDescription()
+                : Description.getDescription(descriptionWrapper.get());
+
+        return new AddProductCommand(new Product(name.get(), type, manufacturer, description));
     }
 }

--- a/src/main/java/seedu/address/logic/parser/products/AddProductCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/products/AddProductCommandParser.java
@@ -3,6 +3,7 @@ package seedu.address.logic.parser.products;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PRODUCT_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PRODUCT_TYPE;
 
 import java.util.Optional;
 
@@ -12,13 +13,14 @@ import seedu.address.logic.parser.ArgumentTokenizer;
 import seedu.address.logic.parser.Parser;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.products.Product;
+import seedu.address.model.products.Type;
 
 public class AddProductCommandParser implements Parser<AddProductCommand> {
 
     @Override
     public AddProductCommand parse(String args) throws ParseException {
         requireNonNull(args);
-        ArgumentMultimap argMap = ArgumentTokenizer.tokenize(args, PREFIX_PRODUCT_NAME);
+        ArgumentMultimap argMap = ArgumentTokenizer.tokenize(args, PREFIX_PRODUCT_NAME, PREFIX_PRODUCT_TYPE);
 
         Optional<String> name = argMap.getValue(PREFIX_PRODUCT_NAME);
         if (name.isEmpty()) {
@@ -29,6 +31,11 @@ public class AddProductCommandParser implements Parser<AddProductCommand> {
                     AddProductCommand.MESSAGE_USAGE));
         }
 
-        return new AddProductCommand(new Product(name.get()));
+        Optional<String> typeWrapper = argMap.getValue(PREFIX_PRODUCT_TYPE);
+        Type type = typeWrapper.orElse("").equals("")
+                ? Type.getEmptyType()
+                : Type.getType(typeWrapper.get());
+
+        return new AddProductCommand(new Product(name.get(), type));
     }
 }

--- a/src/main/java/seedu/address/logic/parser/products/AddProductCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/products/AddProductCommandParser.java
@@ -1,0 +1,13 @@
+package seedu.address.logic.parser.products;
+
+import seedu.address.logic.commands.products.AddProductCommand;
+import seedu.address.logic.parser.Parser;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+public class AddProductCommandParser implements Parser<AddProductCommand> {
+
+    @Override
+    public AddProductCommand parse(String userInput) throws ParseException {
+        return null;
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/products/AddProductCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/products/AddProductCommandParser.java
@@ -1,13 +1,34 @@
 package seedu.address.logic.parser.products;
 
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PRODUCT_NAME;
+
+import java.util.Optional;
+
 import seedu.address.logic.commands.products.AddProductCommand;
+import seedu.address.logic.parser.ArgumentMultimap;
+import seedu.address.logic.parser.ArgumentTokenizer;
 import seedu.address.logic.parser.Parser;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.products.Product;
 
 public class AddProductCommandParser implements Parser<AddProductCommand> {
 
     @Override
-    public AddProductCommand parse(String userInput) throws ParseException {
-        return null;
+    public AddProductCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMap = ArgumentTokenizer.tokenize(args, PREFIX_PRODUCT_NAME);
+
+        Optional<String> name = argMap.getValue(PREFIX_PRODUCT_NAME);
+        if (name.isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    AddProductCommand.MESSAGE_USAGE));
+        } else if (name.get().length() == 0) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    AddProductCommand.MESSAGE_USAGE));
+        }
+
+        return new AddProductCommand(new Product(name.get()));
     }
 }

--- a/src/main/java/seedu/address/logic/parser/products/DeleteProductCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/products/DeleteProductCommandParser.java
@@ -1,0 +1,30 @@
+package seedu.address.logic.parser.products;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.products.DeleteProductCommand;
+import seedu.address.logic.parser.Parser;
+import seedu.address.logic.parser.ParserUtil;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new DeleteProductCommand object
+ */
+public class DeleteProductCommandParser implements Parser<DeleteProductCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the DeleteProductCommand
+     * and returns a DeleteProductCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public DeleteProductCommand parse(String args) throws ParseException {
+        try {
+            Index index = ParserUtil.parseIndex(args);
+            return new DeleteProductCommand(index);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteProductCommand.MESSAGE_USAGE), pe);
+        }
+    }
+}

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -7,6 +7,7 @@ import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.model.contact.Contact;
 import seedu.address.model.mail.Template;
+import seedu.address.model.products.Product;
 
 /**
  * The API of the Model component.
@@ -15,6 +16,7 @@ public interface Model {
     /** {@code Predicate} that always evaluate to true */
     Predicate<Contact> PREDICATE_SHOW_ALL_CONTACTS = unused -> true;
     Predicate<Template> PREDICATE_SHOW_ALL_TEMPLATES = unused -> true;
+    Predicate<Product> PREDICATE_SHOW_ALL_PRODUCTS = unused -> true;
 
     /**
      * Replaces user prefs data with the data in {@code userPrefs}.
@@ -97,11 +99,31 @@ public interface Model {
      */
     void setContact(Contact target, Contact editedContact);
 
+    /**
+     * Returns true if a product with the same identity as {@code product} exists in the address book.
+     */
+    boolean hasProduct(Product product);
+
+    /**
+     * Adds the given product.
+     * {@code product} must not already exist in the address book
+     */
+    void addProduct(Product product);
+
+    /**
+     * Deletes the given product.
+     * The product must exist in the address book.
+     */
+    void deleteProduct(Product product);
+
     /** Returns an unmodifiable view of the filtered contact list */
     ObservableList<Contact> getFilteredContactList();
 
     /** Returns an unmodifiable view of the filtered template list */
     ObservableList<Template> getFilteredTemplateList();
+
+    /** Returns an unmodifiable view of the filtered product list */
+    ObservableList<Product> getFilteredProductList();
 
     /**
      * Updates the filter of the filtered contact list to filter by the given {@code predicate}.
@@ -115,4 +137,9 @@ public interface Model {
      */
     void updateFilteredTemplateList(Predicate<Template> predicate);
 
+    /**
+     * Updates the filter of the filtered product list to filter by the given {@code predicate}.
+     * @throws NullPointerException if {@code predicate} is null.
+     */
+    void updateFilteredProductList(Predicate<Product> predicate);
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -155,7 +155,7 @@ public class ModelManager implements Model {
     @Override
     public void deleteProduct(Product product) {
         requireNonNull(product);
-        // unimplemented
+        addressBook.removeProduct(product);
     }
 
     //=========== Filtered Person List Accessors =============================================================

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -13,6 +13,7 @@ import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.model.contact.Contact;
 import seedu.address.model.mail.Template;
+import seedu.address.model.products.Product;
 
 /**
  * Represents the in-memory model of the address book data.
@@ -24,6 +25,8 @@ public class ModelManager implements Model {
     private final UserPrefs userPrefs;
     private final FilteredList<Contact> filteredPersons;
     private final FilteredList<Template> filteredTemplates;
+
+    private final FilteredList<Product> filteredProducts;
 
     /**
      * Initializes a ModelManager with the given addressBook and userPrefs.
@@ -38,6 +41,8 @@ public class ModelManager implements Model {
         this.userPrefs = new UserPrefs(userPrefs);
         filteredPersons = new FilteredList<>(this.addressBook.getPersonList());
         filteredTemplates = new FilteredList<>(this.addressBook.getTemplateList());
+
+        filteredProducts = new FilteredList<>(this.addressBook.getProductList());
     }
 
     public ModelManager() {
@@ -132,6 +137,27 @@ public class ModelManager implements Model {
         addressBook.setPerson(target, editedPerson);
     }
 
+    //=========== Products ================================================================================
+
+    @Override
+    public boolean hasProduct(Product product) {
+        requireNonNull(product);
+        return addressBook.hasProduct(product);
+    }
+
+    @Override
+    public void addProduct(Product product) {
+        requireNonNull(product);
+        addressBook.addProduct(product);
+        updateFilteredProductList(PREDICATE_SHOW_ALL_PRODUCTS);
+    }
+
+    @Override
+    public void deleteProduct(Product product) {
+        requireNonNull(product);
+        // unimplemented
+    }
+
     //=========== Filtered Person List Accessors =============================================================
 
     /**
@@ -152,6 +178,15 @@ public class ModelManager implements Model {
         return filteredTemplates;
     }
 
+    /**
+     * Returns an unmodifiable view of the list of {@code Product} backed by the internal list of
+     * {@code versionedAddressBook}
+     */
+    @Override
+    public ObservableList<Product> getFilteredProductList() {
+        return filteredProducts;
+    }
+
     @Override
     public void updateFilteredContactList(Predicate<Contact> predicate) {
         requireNonNull(predicate);
@@ -162,6 +197,12 @@ public class ModelManager implements Model {
     public void updateFilteredTemplateList(Predicate<Template> predicate) {
         requireNonNull(predicate);
         filteredTemplates.setPredicate(predicate);
+    }
+
+    @Override
+    public void updateFilteredProductList(Predicate<Product> predicate) {
+        requireNonNull(predicate);
+        filteredProducts.setPredicate(predicate);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/MyCrm.java
+++ b/src/main/java/seedu/address/model/MyCrm.java
@@ -9,6 +9,8 @@ import seedu.address.model.contact.Contact;
 import seedu.address.model.contact.UniqueContactList;
 import seedu.address.model.mail.Template;
 import seedu.address.model.mail.UniqueTemplateList;
+import seedu.address.model.products.Product;
+import seedu.address.model.products.UniqueProductList;
 
 /**
  * Wraps all data at the address-book level
@@ -32,6 +34,11 @@ public class MyCrm implements ReadOnlyAddressBook {
     private final UniqueTemplateList templates;
     {
         templates = new UniqueTemplateList();
+    }
+
+    private final UniqueProductList products;
+    {
+        products = new UniqueProductList();
     }
 
     public MyCrm() {}
@@ -63,6 +70,14 @@ public class MyCrm implements ReadOnlyAddressBook {
     }
 
     /**
+     * Replaces the contents of the product list with {@code products}.
+     * {@code products} must not contain duplicate products.
+     */
+    public void setProducts(List<Product> products) {
+        this.products.setProducts(products);
+    }
+
+    /**
      * Resets the existing data of this {@code AddressBook} with {@code newData}.
      */
     public void resetData(ReadOnlyAddressBook newData) {
@@ -70,6 +85,7 @@ public class MyCrm implements ReadOnlyAddressBook {
 
         setPersons(newData.getPersonList());
         setTemplates(newData.getTemplateList());
+        setProducts(newData.getProductList());
     }
 
     //// person-level operations
@@ -145,6 +161,32 @@ public class MyCrm implements ReadOnlyAddressBook {
         templates.remove(key);
     }
 
+    //// Product Methods
+
+    /**
+     * Adds a product to the address book.
+     * The product must not already exist in MyCRM.
+     */
+    public void addProduct(Product p) {
+        products.add(p);
+    }
+
+    /**
+     * Returns true if a product with the same identity as {@code product} exists in MyCRM.
+     */
+    public boolean hasProduct(Product product) {
+        requireNonNull(product);
+        return products.contains(product);
+    }
+
+    /**
+     * Removes {@code key} from this {@code MyCRM}.
+     * {@code key} must exist in MyCRM.
+     */
+    public void removeProduct(Product key) {
+        products.remove(key);
+    }
+
     //// util methods
 
     @Override
@@ -161,6 +203,11 @@ public class MyCrm implements ReadOnlyAddressBook {
     @Override
     public ObservableList<Template> getTemplateList() {
         return templates.asUnmodifiableObservableList();
+    }
+
+    @Override
+    public ObservableList<Product> getProductList() {
+        return products.asUnmodifiableObservableList();
     }
 
     @Override

--- a/src/main/java/seedu/address/model/ReadOnlyAddressBook.java
+++ b/src/main/java/seedu/address/model/ReadOnlyAddressBook.java
@@ -3,6 +3,7 @@ package seedu.address.model;
 import javafx.collections.ObservableList;
 import seedu.address.model.contact.Contact;
 import seedu.address.model.mail.Template;
+import seedu.address.model.products.Product;
 
 /**
  * Unmodifiable view of an address book
@@ -20,4 +21,10 @@ public interface ReadOnlyAddressBook {
      * This list will not contain any template persons.
      */
     ObservableList<Template> getTemplateList();
+
+    /**
+     * Returns an unmodifiable view of the products list.
+     * This list will not contain any duplicate products.
+     */
+    ObservableList<Product> getProductList();
 }

--- a/src/main/java/seedu/address/model/products/Description.java
+++ b/src/main/java/seedu/address/model/products/Description.java
@@ -1,0 +1,54 @@
+package seedu.address.model.products;
+
+import static java.util.Objects.requireNonNull;
+
+public class Description {
+    private static final Description EMPTY_DESCRIPTION = new Description();
+    private final String contents;
+
+    private Description() {
+        this.contents = null;
+    }
+
+    private Description(String contents) {
+        this.contents = contents;
+    }
+
+    public static Description getDescription(String contents) {
+        requireNonNull(contents);
+
+        if (contents.length() == 0) {
+            return EMPTY_DESCRIPTION;
+        } else {
+            return new Description(contents);
+        }
+    }
+
+    public static Description getEmptyDescription() {
+        return EMPTY_DESCRIPTION;
+    }
+
+    protected boolean isEmpty() {
+        return this == EMPTY_DESCRIPTION;
+    }
+
+    @Override
+    public String toString() {
+        return this.isEmpty() ? "" : this.contents;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == this) {
+            return true;
+        }
+        if (o == null) {
+            return false;
+        }
+
+        if (o instanceof Description && o != EMPTY_DESCRIPTION) {
+            return ((Description) o).contents.equals(this.contents);
+        }
+        return false;
+    }
+}

--- a/src/main/java/seedu/address/model/products/Manufacturer.java
+++ b/src/main/java/seedu/address/model/products/Manufacturer.java
@@ -1,0 +1,54 @@
+package seedu.address.model.products;
+
+import static java.util.Objects.requireNonNull;
+
+public class Manufacturer {
+    private static final Manufacturer EMPTY_MANUFACTURER = new Manufacturer();
+    private final String name;
+
+    private Manufacturer() {
+        this.name = null;
+    }
+
+    private Manufacturer(String name) {
+        this.name = name;
+    }
+
+    public static Manufacturer getManufacturer(String name) {
+        requireNonNull(name);
+
+        if (name.length() == 0) {
+            return EMPTY_MANUFACTURER;
+        } else {
+            return new Manufacturer(name);
+        }
+    }
+
+    public static Manufacturer getEmptyManufacturer() {
+        return EMPTY_MANUFACTURER;
+    }
+
+    protected boolean isEmpty() {
+        return this == EMPTY_MANUFACTURER;
+    }
+
+    @Override
+    public String toString() {
+        return this.isEmpty() ? "" : this.name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == this) {
+            return true;
+        }
+        if (o == null) {
+            return false;
+        }
+
+        if (o instanceof Manufacturer && o != EMPTY_MANUFACTURER) {
+            return ((Manufacturer) o).name.equals(this.name);
+        }
+        return false;
+    }
+}

--- a/src/main/java/seedu/address/model/products/Product.java
+++ b/src/main/java/seedu/address/model/products/Product.java
@@ -1,0 +1,38 @@
+package seedu.address.model.products;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Represents a product in MyCRM.
+ */
+public class Product {
+    private final String productName;
+
+    /**
+     * Create a product.
+     * @param productName Name of the product.
+     */
+    public Product(String productName) {
+        requireNonNull(productName);
+
+        this.productName = productName;
+    }
+
+    public String getName() {
+        return this.productName;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o instanceof Product) {
+            Product p = (Product) o;
+            return p.productName.equals(this.productName);
+        }
+        return false;
+    }
+
+    @Override
+    public String toString() {
+        return "Product: " + productName;
+    }
+}

--- a/src/main/java/seedu/address/model/products/Product.java
+++ b/src/main/java/seedu/address/model/products/Product.java
@@ -52,6 +52,19 @@ public class Product {
         return this.description;
     }
 
+    /**
+     * Returns true if both products have the same name.
+     * This defines a weaker notion of equality between two contacts.
+     */
+    public boolean isSameProduct(Product otherProduct) {
+        if (otherProduct == this) {
+            return true;
+        }
+
+        return otherProduct != null
+                && otherProduct.productName.equals(this.productName);
+    }
+
     @Override
     public boolean equals(Object o) {
         if (o == this) {

--- a/src/main/java/seedu/address/model/products/Product.java
+++ b/src/main/java/seedu/address/model/products/Product.java
@@ -8,16 +8,18 @@ import static java.util.Objects.requireNonNull;
 public class Product {
     private final String productName;
     private final Type type;
+    private final Manufacturer manufacturer;
 
     /**
      * Create a product.
      * @param productName Name of the product.
      */
-    public Product(String productName, Type type) {
+    public Product(String productName, Type type, Manufacturer manufacturer) {
         requireNonNull(productName);
 
         this.productName = productName;
         this.type = type;
+        this.manufacturer = manufacturer;
     }
 
     public String getName() {
@@ -32,6 +34,14 @@ public class Product {
         return this.type;
     }
 
+    public boolean hasManufacturer() {
+        return !this.manufacturer.isEmpty();
+    }
+
+    public Manufacturer getManufacturer() {
+        return this.manufacturer;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (o == this) {
@@ -43,7 +53,9 @@ public class Product {
 
         if (o instanceof Product) {
             Product p = (Product) o;
-            return p.productName.equals(this.productName) && p.type.equals(this.type);
+            return p.productName.equals(this.productName)
+                    && p.type.equals(this.type)
+                    && p.manufacturer.equals(this.manufacturer);
         }
         return false;
     }
@@ -51,6 +63,7 @@ public class Product {
     @Override
     public String toString() {
         return "Product: " + this.productName
-                + (this.type.isEmpty() ? "" : " Type: " + this.type);
+                + (this.type.isEmpty() ? "" : " Type: " + this.type)
+                + (this.manufacturer.isEmpty() ? "" : " Manufacturer: " + this.manufacturer);
     }
 }

--- a/src/main/java/seedu/address/model/products/Product.java
+++ b/src/main/java/seedu/address/model/products/Product.java
@@ -9,17 +9,19 @@ public class Product {
     private final String productName;
     private final Type type;
     private final Manufacturer manufacturer;
+    private final Description description;
 
     /**
      * Create a product.
      * @param productName Name of the product.
      */
-    public Product(String productName, Type type, Manufacturer manufacturer) {
+    public Product(String productName, Type type, Manufacturer manufacturer, Description description) {
         requireNonNull(productName);
 
         this.productName = productName;
         this.type = type;
         this.manufacturer = manufacturer;
+        this.description = description;
     }
 
     public String getName() {
@@ -42,6 +44,14 @@ public class Product {
         return this.manufacturer;
     }
 
+    public boolean hasDescription() {
+        return !this.description.isEmpty();
+    }
+
+    public Description getDescription() {
+        return this.description;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (o == this) {
@@ -55,7 +65,8 @@ public class Product {
             Product p = (Product) o;
             return p.productName.equals(this.productName)
                     && p.type.equals(this.type)
-                    && p.manufacturer.equals(this.manufacturer);
+                    && p.manufacturer.equals(this.manufacturer)
+                    && p.description.equals(this.description);
         }
         return false;
     }
@@ -64,6 +75,7 @@ public class Product {
     public String toString() {
         return "Product: " + this.productName
                 + (this.type.isEmpty() ? "" : " Type: " + this.type)
-                + (this.manufacturer.isEmpty() ? "" : " Manufacturer: " + this.manufacturer);
+                + (this.manufacturer.isEmpty() ? "" : " Manufacturer: " + this.manufacturer)
+                + (this.description.isEmpty() ? "" : " Description: " + this.description);
     }
 }

--- a/src/main/java/seedu/address/model/products/Product.java
+++ b/src/main/java/seedu/address/model/products/Product.java
@@ -7,32 +7,50 @@ import static java.util.Objects.requireNonNull;
  */
 public class Product {
     private final String productName;
+    private final Type type;
 
     /**
      * Create a product.
      * @param productName Name of the product.
      */
-    public Product(String productName) {
+    public Product(String productName, Type type) {
         requireNonNull(productName);
 
         this.productName = productName;
+        this.type = type;
     }
 
     public String getName() {
         return this.productName;
     }
 
+    public boolean hasType() {
+        return !this.type.isEmpty();
+    }
+
+    public Type getType() {
+        return this.type;
+    }
+
     @Override
     public boolean equals(Object o) {
+        if (o == this) {
+            return true;
+        }
+        if (o == null) {
+            return false;
+        }
+
         if (o instanceof Product) {
             Product p = (Product) o;
-            return p.productName.equals(this.productName);
+            return p.productName.equals(this.productName) && p.type.equals(this.type);
         }
         return false;
     }
 
     @Override
     public String toString() {
-        return "Product: " + productName;
+        return "Product: " + this.productName
+                + (this.type.isEmpty() ? "" : " Type: " + this.type);
     }
 }

--- a/src/main/java/seedu/address/model/products/ProductNameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/products/ProductNameContainsKeywordsPredicate.java
@@ -1,0 +1,27 @@
+package seedu.address.model.products;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.StringUtil;
+
+public class ProductNameContainsKeywordsPredicate implements Predicate<Product> {
+    private final List<String> keywords;
+
+    public ProductNameContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Product product) {
+        return keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(product.getName(), keyword));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof ProductNameContainsKeywordsPredicate // instanceof handles nulls
+                && keywords.equals(((ProductNameContainsKeywordsPredicate) other).keywords)); // state check
+    }
+}

--- a/src/main/java/seedu/address/model/products/Type.java
+++ b/src/main/java/seedu/address/model/products/Type.java
@@ -1,0 +1,54 @@
+package seedu.address.model.products;
+
+import static java.util.Objects.requireNonNull;
+
+public class Type {
+    private static final Type EMPTY_TYPE = new Type();
+    private final String name;
+
+    private Type() {
+        this.name = null;
+    }
+
+    private Type(String type) {
+        this.name = type;
+    }
+
+    public static Type getType(String name) {
+        requireNonNull(name);
+
+        if (name.length() == 0) {
+            return EMPTY_TYPE;
+        } else {
+            return new Type(name);
+        }
+    }
+
+    public static Type getEmptyType() {
+        return EMPTY_TYPE;
+    }
+
+    protected boolean isEmpty() {
+        return this == EMPTY_TYPE;
+    }
+
+    @Override
+    public String toString() {
+        return this.isEmpty() ? "" : this.name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == this) {
+            return true;
+        }
+        if (o == null) {
+            return false;
+        }
+
+        if (o instanceof Type && o != EMPTY_TYPE) {
+            return ((Type) o).name.equals(this.name);
+        }
+        return false;
+    }
+}

--- a/src/main/java/seedu/address/model/products/UniqueProductList.java
+++ b/src/main/java/seedu/address/model/products/UniqueProductList.java
@@ -1,0 +1,138 @@
+package seedu.address.model.products;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+
+import java.util.Iterator;
+import java.util.List;
+
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import seedu.address.model.products.exceptions.DuplicateProductException;
+import seedu.address.model.products.exceptions.ProductNotFoundException;
+
+/**
+ * A list of products that enforces uniqueness between its elements and does not allow nulls.
+ * A product is considered unique by comparing using {@code Product#isSameProduct(Product)}.
+ * As such, adding and updating of products uses Product#isSameProduct(Product) for equality
+ * so as to ensure that the Product being added or updated is unique in terms of identity in the UniqueProductList.
+ * However, the removal of a product uses Product#equals(Object) so
+ * as to ensure that the product with exactly the same fields will be removed.
+ *
+ * Supports a minimal set of list operations.
+ *
+ * @see Product#isSameProduct(Product)
+ */
+public class UniqueProductList implements Iterable<Product> {
+
+    private final ObservableList<Product> internalList = FXCollections.observableArrayList();
+    private final ObservableList<Product> internalUnmodifiableList =
+            FXCollections.unmodifiableObservableList(internalList);
+
+    /**
+     * Returns true if the list contains an equivalent product as the given argument.
+     */
+    public boolean contains(Product toCheck) {
+        requireNonNull(toCheck);
+        return internalList.stream().anyMatch(toCheck::isSameProduct);
+    }
+
+    /**
+     * Adds a product to the list.
+     * The product must not already exist in the list.
+     */
+    public void add(Product toAdd) {
+        requireNonNull(toAdd);
+        if (contains(toAdd)) {
+            throw new DuplicateProductException();
+        }
+        internalList.add(toAdd);
+    }
+
+    /**
+     * Replaces the product {@code target} in the list with {@code editedProduct}.
+     * {@code target} must exist in the list.
+     * The product identity of {@code editedProduct} must not be the same as another existing product in the list.
+     */
+    public void setProduct(Product target, Product editedProduct) {
+        requireAllNonNull(target, editedProduct);
+
+        int index = internalList.indexOf(target);
+        if (index == -1) {
+            throw new ProductNotFoundException();
+        }
+
+        if (!target.isSameProduct(editedProduct) && contains(editedProduct)) {
+            throw new DuplicateProductException();
+        }
+
+        internalList.set(index, editedProduct);
+    }
+
+    /**
+     * Removes the equivalent product from the list.
+     * The product must exist in the list.
+     */
+    public void remove(Product toRemove) {
+        requireNonNull(toRemove);
+        if (!internalList.remove(toRemove)) {
+            throw new ProductNotFoundException();
+        }
+    }
+
+    public void setProducts(UniqueProductList replacement) {
+        requireNonNull(replacement);
+        internalList.setAll(replacement.internalList);
+    }
+
+    /**
+     * Replaces the products of this list with {@code products}.
+     * {@code products} must not contain duplicate products.
+     */
+    public void setProducts(List<Product> products) {
+        requireAllNonNull(products);
+        if (!productsAreUnique(products)) {
+            throw new DuplicateProductException();
+        }
+
+        internalList.setAll(products);
+    }
+
+    /**
+     * Returns the backing list as an unmodifiable {@code ObservableList}.
+     */
+    public ObservableList<Product> asUnmodifiableObservableList() {
+        return internalUnmodifiableList;
+    }
+
+    @Override
+    public Iterator<Product> iterator() {
+        return internalList.iterator();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof UniqueProductList // instanceof handles nulls
+                        && internalList.equals(((UniqueProductList) other).internalList));
+    }
+
+    @Override
+    public int hashCode() {
+        return internalList.hashCode();
+    }
+
+    /**
+     * Returns true if {@code products} contains only unique products.
+     */
+    private boolean productsAreUnique(List<Product> products) {
+        for (int i = 0; i < products.size() - 1; i++) {
+            for (int j = i + 1; j < products.size(); j++) {
+                if (products.get(i).isSameProduct(products.get(j))) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+}

--- a/src/main/java/seedu/address/model/products/exceptions/DuplicateProductException.java
+++ b/src/main/java/seedu/address/model/products/exceptions/DuplicateProductException.java
@@ -1,0 +1,11 @@
+package seedu.address.model.products.exceptions;
+
+/**
+ * Signals that the operation will result in duplicate Products (Products are considered duplicates if they have the
+ * same identity).
+ */
+public class DuplicateProductException extends RuntimeException {
+    public DuplicateProductException() {
+        super("Operation would result in duplicate contacts");
+    }
+}

--- a/src/main/java/seedu/address/model/products/exceptions/ProductNotFoundException.java
+++ b/src/main/java/seedu/address/model/products/exceptions/ProductNotFoundException.java
@@ -1,0 +1,6 @@
+package seedu.address.model.products.exceptions;
+
+/**
+ * Signals that the operation is unable to find the specified product.
+ */
+public class ProductNotFoundException extends RuntimeException {}

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -33,6 +33,7 @@ public class MainWindow extends UiPart<Stage> {
     // Independent Ui parts residing in this Ui container
     private ContactListPanel contactListPanel;
     private TemplateListPanel templateListPanel;
+    private ProductListPanel productListPanel;
     private ResultDisplay resultDisplay;
     private HelpWindow helpWindow;
 
@@ -47,6 +48,9 @@ public class MainWindow extends UiPart<Stage> {
 
     @FXML
     private StackPane templateListPanelPlaceholder;
+
+    @FXML
+    private StackPane productListPanelPlaceholder;
 
     @FXML
     private StackPane resultDisplayPlaceholder;
@@ -118,12 +122,21 @@ public class MainWindow extends UiPart<Stage> {
         personListPanelPlaceholder.managedProperty().bind(personListPanelPlaceholder.visibleProperty());
         personListPanelPlaceholder.getChildren().add(contactListPanel.getRoot());
 
+        personListPanelPlaceholder.setVisible(false);
+
         templateListPanel = new TemplateListPanel(logic.getFilteredTemplateList());
         templateListPanelPlaceholder.managedProperty().bind(templateListPanelPlaceholder.visibleProperty());
         templateListPanelPlaceholder.getChildren().add(templateListPanel.getRoot());
 
         // Hides initial template
         templateListPanelPlaceholder.setVisible(false);
+
+        productListPanel = new ProductListPanel(logic.getFilteredProductList());
+        productListPanelPlaceholder.managedProperty().bind(productListPanelPlaceholder.visibleProperty());
+        productListPanelPlaceholder.getChildren().add(productListPanel.getRoot());
+
+        // Hides initial template
+        productListPanelPlaceholder.setVisible(true);
 
         resultDisplay = new ResultDisplay();
         resultDisplayPlaceholder.getChildren().add(resultDisplay.getRoot());
@@ -180,8 +193,9 @@ public class MainWindow extends UiPart<Stage> {
      */
     @FXML
     private void handleTemplate(boolean show) {
-        templateListPanelPlaceholder.setVisible(show);
-        personListPanelPlaceholder.setVisible(!show);
+        productListPanelPlaceholder.setVisible(true);
+        templateListPanelPlaceholder.setVisible(false);
+        personListPanelPlaceholder.setVisible(false);
     }
 
     public ContactListPanel getContactListPanel() {

--- a/src/main/java/seedu/address/ui/ProductCard.java
+++ b/src/main/java/seedu/address/ui/ProductCard.java
@@ -1,0 +1,69 @@
+package seedu.address.ui;
+
+import javafx.fxml.FXML;
+import javafx.scene.control.Label;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Region;
+import seedu.address.model.products.Product;
+
+/**
+ * An UI component that displays information of a {@code Product}.
+ */
+public class ProductCard extends UiPart<Region> {
+
+    private static final String FXML = "ProductListCard.fxml";
+
+    /**
+     * Note: Certain keywords such as "location" and "resources" are reserved keywords in JavaFX.
+     * As a consequence, UI elements' variable names cannot be set to such keywords
+     * or an exception will be thrown by JavaFX during runtime.
+     *
+     * @see <a href="https://github.com/se-edu/addressbook-level4/issues/336">The issue on AddressBook level 4</a>
+     */
+
+    public final Product product;
+
+    @FXML
+    private HBox cardPane;
+    @FXML
+    private Label name;
+    @FXML
+    private Label id;
+    @FXML
+    private Label type;
+    @FXML
+    private Label manufacturer;
+    @FXML
+    private Label description;
+
+    /**
+     * Creates a {@code PersonCode} with the given {@code Person} and index to display.
+     */
+    public ProductCard(Product product, int displayedIndex) {
+        super(FXML);
+        this.product = product;
+        id.setText(displayedIndex + ". ");
+        name.setText(product.getName());
+        type.setText(product.getType().toString());
+        manufacturer.setText(product.getManufacturer().toString());
+        description.setText(product.getDescription().toString());
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof ProductCard)) {
+            return false;
+        }
+
+        // state check
+        ProductCard card = (ProductCard) other;
+        return id.getText().equals(card.id.getText())
+                && product.equals(card.product);
+    }
+}

--- a/src/main/java/seedu/address/ui/ProductListPanel.java
+++ b/src/main/java/seedu/address/ui/ProductListPanel.java
@@ -1,0 +1,48 @@
+package seedu.address.ui;
+
+import java.util.logging.Logger;
+
+import javafx.collections.ObservableList;
+import javafx.fxml.FXML;
+import javafx.scene.control.ListCell;
+import javafx.scene.control.ListView;
+import javafx.scene.layout.Region;
+import seedu.address.commons.core.LogsCenter;
+import seedu.address.model.products.Product;
+
+/**
+ * Panel containing the list of persons.
+ */
+public class ProductListPanel extends UiPart<Region> {
+    private static final String FXML = "ProductListPanel.fxml";
+    private final Logger logger = LogsCenter.getLogger(ProductListPanel.class);
+
+    @FXML
+    private ListView<Product> productListView;
+
+    /**
+     * Creates a {@code ProductListPanel} with the given {@code ObservableList}.
+     */
+    public ProductListPanel(ObservableList<Product> productList) {
+        super(FXML);
+        productListView.setItems(productList);
+        productListView.setCellFactory(listView -> new ProductListViewCell());
+    }
+
+    /**
+     * Custom {@code ListCell} that displays the graphics of a {@code Product} using a {@code ProductCard}.
+     */
+    class ProductListViewCell extends ListCell<Product> {
+        @Override
+        protected void updateItem(Product product, boolean empty) {
+            super.updateItem(product, empty);
+
+            if (empty || product == null) {
+                setGraphic(null);
+                setText(null);
+            } else {
+                setGraphic(new ProductCard(product, getIndex() + 1).getRoot());
+            }
+        }
+    }
+}

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -53,6 +53,7 @@
           </padding>
           <StackPane fx:id="personListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
           <StackPane fx:id="templateListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
+          <StackPane fx:id="productListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
         </VBox>
 
         <StackPane fx:id="statusbarPlaceholder" VBox.vgrow="NEVER" />

--- a/src/main/resources/view/ProductListCard.fxml
+++ b/src/main/resources/view/ProductListCard.fxml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.layout.ColumnConstraints?>
+<?import javafx.scene.layout.FlowPane?>
+<?import javafx.scene.layout.GridPane?>
+<?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.Region?>
+<?import javafx.scene.layout.VBox?>
+
+<HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
+    <GridPane HBox.hgrow="ALWAYS">
+        <columnConstraints>
+            <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150" />
+        </columnConstraints>
+        <VBox alignment="CENTER_LEFT" minHeight="105" GridPane.columnIndex="0">
+            <padding>
+                <Insets top="5" right="5" bottom="5" left="15" />
+            </padding>
+            <HBox spacing="5" alignment="CENTER_LEFT">
+                <Label fx:id="id" styleClass="cell_big_label">
+                    <minWidth>
+                        <!-- Ensures that the label text is never truncated -->
+                        <Region fx:constant="USE_PREF_SIZE" />
+                    </minWidth>
+                </Label>
+                <Label fx:id="name" text="\$first" styleClass="cell_big_label" />
+            </HBox>
+            <Label fx:id="type" styleClass="cell_small_label" text="\$type" />
+            <Label fx:id="manufacturer" styleClass="cell_small_label" text="\$manufacturer" />
+            <Label fx:id="description" styleClass="cell_small_label" text="\$description" />
+        </VBox>
+    </GridPane>
+</HBox>

--- a/src/main/resources/view/ProductListPanel.fxml
+++ b/src/main/resources/view/ProductListPanel.fxml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.scene.control.ListView?>
+<?import javafx.scene.layout.VBox?>
+
+<VBox xmlns="http://javafx.com/javafx/16" xmlns:fx="http://javafx.com/fxml/1">
+  <ListView fx:id="productListView" VBox.vgrow="ALWAYS" />
+</VBox>

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -93,6 +93,11 @@ public class LogicManagerTest {
         assertThrows(UnsupportedOperationException.class, () -> logic.getFilteredContactList().remove(0));
     }
 
+    @Test
+    public void getFilteredProductList_modifyList_throwsUnsupportedOperationException() {
+        assertThrows(UnsupportedOperationException.class, () -> logic.getFilteredProductList().remove(0));
+    }
+
     /**
      * Executes the command and confirms that
      * - no exceptions are thrown <br>

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -6,6 +6,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PRODUCT_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.testutil.Assert.assertThrows;
 
@@ -25,6 +26,7 @@ import seedu.address.model.contact.NameContainsKeywordsPredicate;
 import seedu.address.model.mail.SubjectContainsKeywordsPredicate;
 import seedu.address.model.mail.Template;
 import seedu.address.testutil.EditContactDescriptorBuilder;
+import seedu.address.testutil.ProductBuilder;
 
 /**
  * Contains helper methods for testing commands.
@@ -70,6 +72,12 @@ public class CommandTestUtil {
 
     public static final EditContactCommand.EditContactDescriptor DESC_AMY;
     public static final EditContactCommand.EditContactDescriptor DESC_BOB;
+
+    public static final String VALID_PRODUCT_NAME = ProductBuilder.DEFAULT_PRODUCT_ONE_NAME;
+
+    public static final String PRODUCT_NAME_DESC = " " + PREFIX_PRODUCT_NAME + VALID_PRODUCT_NAME;
+
+    public static final String INVALID_PRODUCT_NAME_DESC = " " + PREFIX_PRODUCT_NAME + ""; // product name is empty
 
     static {
         DESC_AMY = new EditContactDescriptorBuilder().withName(VALID_NAME_AMY)

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -6,6 +6,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PRODUCT_DESCRIPTION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PRODUCT_MANUFACTURER;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PRODUCT_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PRODUCT_TYPE;
@@ -27,6 +28,7 @@ import seedu.address.model.contact.Contact;
 import seedu.address.model.contact.NameContainsKeywordsPredicate;
 import seedu.address.model.mail.SubjectContainsKeywordsPredicate;
 import seedu.address.model.mail.Template;
+import seedu.address.model.products.Description;
 import seedu.address.model.products.Manufacturer;
 import seedu.address.model.products.Type;
 import seedu.address.testutil.EditContactDescriptorBuilder;
@@ -80,13 +82,17 @@ public class CommandTestUtil {
     public static final String VALID_PRODUCT_NAME = ProductBuilder.DEFAULT_PRODUCT_ONE_NAME;
     public static final Type VALID_PRODUCT_TYPE = ProductBuilder.DEFAULT_PRODUCT_ONE_TYPE;
     public static final Manufacturer VALID_PRODUCT_MANUFACTURER = ProductBuilder.DEFAULT_PRODUCT_ONE_MANUFACTURER;
+    public static final Description VALID_PRODUCT_DESCRIPTION = ProductBuilder.DEFAULT_PRODUCT_ONE_DESCRIPTION;
 
     public static final String PRODUCT_NAME_DESC = " " + PREFIX_PRODUCT_NAME + VALID_PRODUCT_NAME;
     public static final String PRODUCT_TYPE_DESC = " " + PREFIX_PRODUCT_TYPE + VALID_PRODUCT_TYPE;
     public static final String PRODUCT_MANUFACTURER_DESC = " " + PREFIX_PRODUCT_MANUFACTURER
             + VALID_PRODUCT_MANUFACTURER;
+    public static final String PRODUCT_DESCRIPTION_DESC = " " + PREFIX_PRODUCT_DESCRIPTION + VALID_PRODUCT_DESCRIPTION;
+
     public static final String PRODUCT_EMPTY_TYPE_DESC = " " + PREFIX_PRODUCT_TYPE;
     public static final String PRODUCT_EMPTY_MANUFACTURER_DESC = " " + PREFIX_PRODUCT_MANUFACTURER;
+    public static final String PRODUCT_EMPTY_DESCRIPTION_DESC = " " + PREFIX_PRODUCT_DESCRIPTION;
 
     public static final String INVALID_PRODUCT_NAME_DESC = " " + PREFIX_PRODUCT_NAME
             + PRODUCT_TYPE_DESC; // product name is empty

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -7,6 +7,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PRODUCT_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PRODUCT_TYPE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.testutil.Assert.assertThrows;
 
@@ -25,6 +26,7 @@ import seedu.address.model.contact.Contact;
 import seedu.address.model.contact.NameContainsKeywordsPredicate;
 import seedu.address.model.mail.SubjectContainsKeywordsPredicate;
 import seedu.address.model.mail.Template;
+import seedu.address.model.products.Type;
 import seedu.address.testutil.EditContactDescriptorBuilder;
 import seedu.address.testutil.ProductBuilder;
 
@@ -74,10 +76,14 @@ public class CommandTestUtil {
     public static final EditContactCommand.EditContactDescriptor DESC_BOB;
 
     public static final String VALID_PRODUCT_NAME = ProductBuilder.DEFAULT_PRODUCT_ONE_NAME;
+    public static final Type VALID_PRODUCT_TYPE = ProductBuilder.DEFAULT_PRODUCT_ONE_TYPE;
 
     public static final String PRODUCT_NAME_DESC = " " + PREFIX_PRODUCT_NAME + VALID_PRODUCT_NAME;
+    public static final String PRODUCT_TYPE_DESC = " " + PREFIX_PRODUCT_TYPE + VALID_PRODUCT_TYPE;
+    public static final String PRODUCT_EMPTY_TYPE_DESC = " " + PREFIX_PRODUCT_TYPE;
 
-    public static final String INVALID_PRODUCT_NAME_DESC = " " + PREFIX_PRODUCT_NAME + ""; // product name is empty
+    public static final String INVALID_PRODUCT_NAME_DESC = " " + PREFIX_PRODUCT_NAME
+            + PRODUCT_TYPE_DESC; // product name is empty
 
     static {
         DESC_AMY = new EditContactDescriptorBuilder().withName(VALID_NAME_AMY)

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -30,6 +30,8 @@ import seedu.address.model.mail.SubjectContainsKeywordsPredicate;
 import seedu.address.model.mail.Template;
 import seedu.address.model.products.Description;
 import seedu.address.model.products.Manufacturer;
+import seedu.address.model.products.Product;
+import seedu.address.model.products.ProductNameContainsKeywordsPredicate;
 import seedu.address.model.products.Type;
 import seedu.address.testutil.EditContactDescriptorBuilder;
 import seedu.address.testutil.ProductBuilder;
@@ -176,5 +178,19 @@ public class CommandTestUtil {
                 .collect(Collectors.toList())));
 
         assertEquals(1, model.getFilteredTemplateList().size());
+    }
+
+    /**
+     * Updates {@code model}'s filtered list to show only the product at the given {@code targetIndex} in the
+     * {@code model}'s address book.
+     */
+    public static void showProductAtIndex(Model model, Index targetIndex) {
+        assertTrue(targetIndex.getZeroBased() < model.getFilteredProductList().size());
+
+        Product product = model.getFilteredProductList().get(targetIndex.getZeroBased());
+        final String[] splitName = product.getName().split("\\s+");
+        model.updateFilteredProductList(new ProductNameContainsKeywordsPredicate(Arrays.asList(splitName[0])));
+
+        assertEquals(1, model.getFilteredProductList().size());
     }
 }

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -6,6 +6,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PRODUCT_MANUFACTURER;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PRODUCT_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PRODUCT_TYPE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
@@ -26,6 +27,7 @@ import seedu.address.model.contact.Contact;
 import seedu.address.model.contact.NameContainsKeywordsPredicate;
 import seedu.address.model.mail.SubjectContainsKeywordsPredicate;
 import seedu.address.model.mail.Template;
+import seedu.address.model.products.Manufacturer;
 import seedu.address.model.products.Type;
 import seedu.address.testutil.EditContactDescriptorBuilder;
 import seedu.address.testutil.ProductBuilder;
@@ -77,10 +79,14 @@ public class CommandTestUtil {
 
     public static final String VALID_PRODUCT_NAME = ProductBuilder.DEFAULT_PRODUCT_ONE_NAME;
     public static final Type VALID_PRODUCT_TYPE = ProductBuilder.DEFAULT_PRODUCT_ONE_TYPE;
+    public static final Manufacturer VALID_PRODUCT_MANUFACTURER = ProductBuilder.DEFAULT_PRODUCT_ONE_MANUFACTURER;
 
     public static final String PRODUCT_NAME_DESC = " " + PREFIX_PRODUCT_NAME + VALID_PRODUCT_NAME;
     public static final String PRODUCT_TYPE_DESC = " " + PREFIX_PRODUCT_TYPE + VALID_PRODUCT_TYPE;
+    public static final String PRODUCT_MANUFACTURER_DESC = " " + PREFIX_PRODUCT_MANUFACTURER
+            + VALID_PRODUCT_MANUFACTURER;
     public static final String PRODUCT_EMPTY_TYPE_DESC = " " + PREFIX_PRODUCT_TYPE;
+    public static final String PRODUCT_EMPTY_MANUFACTURER_DESC = " " + PREFIX_PRODUCT_MANUFACTURER;
 
     public static final String INVALID_PRODUCT_NAME_DESC = " " + PREFIX_PRODUCT_NAME
             + PRODUCT_TYPE_DESC; // product name is empty

--- a/src/test/java/seedu/address/logic/commands/contacts/AddContactCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/contacts/AddContactCommandTest.java
@@ -23,6 +23,7 @@ import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.ReadOnlyUserPrefs;
 import seedu.address.model.contact.Contact;
 import seedu.address.model.mail.Template;
+import seedu.address.model.products.Product;
 import seedu.address.testutil.ContactBuilder;
 
 
@@ -157,6 +158,21 @@ class AddContactCommandTest {
         }
 
         @Override
+        public void addProduct(Product product) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean hasProduct(Product product) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void deleteProduct(Product product) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public ObservableList<Contact> getFilteredContactList() {
             throw new AssertionError("This method should not be called.");
         }
@@ -167,12 +183,22 @@ class AddContactCommandTest {
         }
 
         @Override
+        public ObservableList<Product> getFilteredProductList() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void updateFilteredContactList(Predicate<Contact> predicate) {
             throw new AssertionError("This method should not be called.");
         }
 
         @Override
         public void updateFilteredTemplateList(Predicate<Template> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void updateFilteredProductList(Predicate<Product> predicate) {
             throw new AssertionError("This method should not be called.");
         }
     }

--- a/src/test/java/seedu/address/logic/commands/mails/AddTemplateCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/mails/AddTemplateCommandTest.java
@@ -22,6 +22,7 @@ import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.ReadOnlyUserPrefs;
 import seedu.address.model.contact.Contact;
 import seedu.address.model.mail.Template;
+import seedu.address.model.products.Product;
 import seedu.address.testutil.TemplateBuilder;
 
 class AddTemplateCommandTest {
@@ -157,6 +158,21 @@ class AddTemplateCommandTest {
         }
 
         @Override
+        public void addProduct(Product product) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean hasProduct(Product product) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void deleteProduct(Product product) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public ObservableList<Contact> getFilteredContactList() {
             throw new AssertionError("This method should not be called.");
         }
@@ -167,12 +183,22 @@ class AddTemplateCommandTest {
         }
 
         @Override
+        public ObservableList<Product> getFilteredProductList() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void updateFilteredContactList(Predicate<Contact> predicate) {
             throw new AssertionError("This method should not be called.");
         }
 
         @Override
         public void updateFilteredTemplateList(Predicate<Template> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void updateFilteredProductList(Predicate<Product> predicate) {
             throw new AssertionError("This method should not be called.");
         }
     }

--- a/src/test/java/seedu/address/logic/commands/products/AddProductCommandIntegrationTest.java
+++ b/src/test/java/seedu/address/logic/commands/products/AddProductCommandIntegrationTest.java
@@ -1,0 +1,45 @@
+package seedu.address.logic.commands.products;
+
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalProducts.getTypicalMyCrm;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.products.Product;
+import seedu.address.testutil.ProductBuilder;
+
+/**
+ * Contains integration tests (interaction with the Model) for {@code AddProductCommand}.
+ */
+public class AddProductCommandIntegrationTest {
+
+    private Model model;
+
+    @BeforeEach
+    public void setUp() {
+        model = new ModelManager(getTypicalMyCrm(), new UserPrefs());
+    }
+
+    @Test
+    public void execute_newProduct_success() {
+        Product validProduct = new ProductBuilder().withName("10Gb PCI-E NIC Network Card").withType("Network card")
+                .withManufacturer("10Gtek").withDescription("Support Windows Server/Linux/VMware").build();
+
+        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.addProduct(validProduct);
+
+        assertCommandSuccess(new AddProductCommand(validProduct), model,
+                String.format(AddProductCommand.MESSAGE_SUCCESS, validProduct), expectedModel);
+    }
+
+    @Test
+    public void execute_duplicateProduct_throwsCommandException() {
+        Product productInList = model.getAddressBook().getProductList().get(0);
+        assertCommandFailure(new AddProductCommand(productInList), model, AddProductCommand.MESSAGE_DUPLICATE_PRODUCT);
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/products/AddProductCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/products/AddProductCommandTest.java
@@ -1,29 +1,57 @@
 package seedu.address.logic.commands.products;
 
+import static java.util.Objects.requireNonNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.address.testutil.TypicalContacts.getTypicalAddressBook;
+import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalProducts.INTEL_CPU;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
 
+import javafx.collections.ObservableList;
+import seedu.address.commons.core.GuiSettings;
 import seedu.address.logic.commands.ClearCommand;
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
-import seedu.address.model.ModelManager;
-import seedu.address.model.UserPrefs;
+import seedu.address.model.MyCrm;
+import seedu.address.model.ReadOnlyAddressBook;
+import seedu.address.model.ReadOnlyUserPrefs;
+import seedu.address.model.contact.Contact;
+import seedu.address.model.mail.Template;
 import seedu.address.model.products.Product;
 import seedu.address.testutil.ProductBuilder;
 
 public class AddProductCommandTest {
 
-    private Model model;
+    @Test
+    public void constructor_nullProduct_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new AddProductCommand(null));
+    }
 
     @Test
-    public void execute() {
-        model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
-        Product p = new ProductBuilder().build();
+    public void execute_productAcceptedByModel_addSuccessful() throws Exception {
+        ModelStubAcceptingProductAdded modelStub = new ModelStubAcceptingProductAdded();
 
-        assertCommandSuccess(new AddProductCommand(p), model, p.toString(), model);
+        CommandResult commandResult = new AddProductCommand(INTEL_CPU).execute(modelStub);
+
+        assertEquals(String.format(AddProductCommand.MESSAGE_SUCCESS, INTEL_CPU), commandResult.getFeedbackToUser());
+        assertEquals(Arrays.asList(INTEL_CPU), modelStub.productsAdded);
+    }
+
+    @Test
+    public void execute_duplicateProduct_throwsCommandException() {
+        AddProductCommand addCommand = new AddProductCommand(INTEL_CPU);
+        ModelStub modelStub = new ModelStubWithProduct(INTEL_CPU);
+
+        assertThrows(CommandException.class, AddProductCommand.MESSAGE_DUPLICATE_PRODUCT, () ->
+                addCommand.execute(modelStub));
     }
 
     @Test
@@ -49,5 +77,172 @@ public class AddProductCommandTest {
         AddProductCommand cmdWithDiffValues = new AddProductCommand(
                 new ProductBuilder(ProductBuilder.DefaultProductIndex.TWO).build());
         assertFalse(standardCommand.equals(cmdWithDiffValues));
+    }
+
+    /**
+     * A default model stub that have all of the methods failing.
+     */
+    private class ModelStub implements Model {
+        @Override
+        public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ReadOnlyUserPrefs getUserPrefs() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public GuiSettings getGuiSettings() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setGuiSettings(GuiSettings guiSettings) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public Path getAddressBookFilePath() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setAddressBookFilePath(Path addressBookFilePath) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void addContact(Contact person) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void addTemplate(Template template) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setAddressBook(ReadOnlyAddressBook newData) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ReadOnlyAddressBook getAddressBook() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean hasContact(Contact person) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean hasTemplate(Template person) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void deleteContact(Contact target) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void deleteTemplate(Template target) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setContact(Contact target, Contact editedPerson) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void addProduct(Product product) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean hasProduct(Product product) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void deleteProduct(Product product) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ObservableList<Contact> getFilteredContactList() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ObservableList<Template> getFilteredTemplateList() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ObservableList<Product> getFilteredProductList() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void updateFilteredContactList(Predicate<Contact> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void updateFilteredTemplateList(Predicate<Template> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void updateFilteredProductList(Predicate<Product> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
+    }
+
+    /**
+     * A Model stub that contains a single product.
+     */
+    private class ModelStubWithProduct extends ModelStub {
+        private final Product product;
+
+        ModelStubWithProduct(Product product) {
+            requireNonNull(product);
+            this.product = product;
+        }
+
+        @Override
+        public boolean hasProduct(Product product) {
+            requireNonNull(product);
+            return this.product.isSameProduct(product);
+        }
+    }
+
+    /**
+     * A Model stub that always accept the product being added.
+     */
+    private class ModelStubAcceptingProductAdded extends ModelStub {
+        final ArrayList<Product> productsAdded = new ArrayList<>();
+
+        @Override
+        public boolean hasProduct(Product product) {
+            requireNonNull(product);
+            return productsAdded.stream().anyMatch(product::isSameProduct);
+        }
+
+        @Override
+        public void addProduct(Product product) {
+            requireNonNull(product);
+            productsAdded.add(product);
+        }
+
+        @Override
+        public ReadOnlyAddressBook getAddressBook() {
+            return new MyCrm();
+        }
     }
 }

--- a/src/test/java/seedu/address/logic/commands/products/AddProductCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/products/AddProductCommandTest.java
@@ -29,11 +29,11 @@ public class AddProductCommandTest {
     @Test
     public void equals() {
         final AddProductCommand standardCommand = new AddProductCommand(
-                new ProductBuilder(ProductBuilder.DefaultProduct.ONE).build());
+                new ProductBuilder(ProductBuilder.DefaultProductIndex.ONE).build());
 
         // same values -> returns true
         AddProductCommand cmdWithSameValues = new AddProductCommand(
-                new ProductBuilder(ProductBuilder.DefaultProduct.ONE).build());
+                new ProductBuilder(ProductBuilder.DefaultProductIndex.ONE).build());
         assertTrue(standardCommand.equals(cmdWithSameValues));
 
         // same object -> returns true
@@ -47,7 +47,7 @@ public class AddProductCommandTest {
 
         // different product -> returns false
         AddProductCommand cmdWithDiffValues = new AddProductCommand(
-                new ProductBuilder(ProductBuilder.DefaultProduct.TWO).build());
+                new ProductBuilder(ProductBuilder.DefaultProductIndex.TWO).build());
         assertFalse(standardCommand.equals(cmdWithDiffValues));
     }
 }

--- a/src/test/java/seedu/address/logic/commands/products/AddProductCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/products/AddProductCommandTest.java
@@ -1,20 +1,53 @@
 package seedu.address.logic.commands.products;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.TypicalContacts.getTypicalAddressBook;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.logic.commands.ClearCommand;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.products.Product;
+import seedu.address.testutil.ProductBuilder;
 
 public class AddProductCommandTest {
 
-    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private Model model;
 
     @Test
     public void execute() {
-        assertCommandSuccess(new AddProductCommand(), model, AddProductCommand.DUMMY_MESSAGE, model);
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        Product p = new ProductBuilder().build();
+
+        assertCommandSuccess(new AddProductCommand(p), model, p.toString(), model);
+    }
+
+    @Test
+    public void equals() {
+        final AddProductCommand standardCommand = new AddProductCommand(
+                new ProductBuilder(ProductBuilder.DefaultProduct.ONE).build());
+
+        // same values -> returns true
+        AddProductCommand cmdWithSameValues = new AddProductCommand(
+                new ProductBuilder(ProductBuilder.DefaultProduct.ONE).build());
+        assertTrue(standardCommand.equals(cmdWithSameValues));
+
+        // same object -> returns true
+        assertTrue(standardCommand.equals(standardCommand));
+
+        // null -> returns false
+        assertFalse(standardCommand.equals(null));
+
+        // different types -> returns false
+        assertFalse(standardCommand.equals(new ClearCommand()));
+
+        // different product -> returns false
+        AddProductCommand cmdWithDiffValues = new AddProductCommand(
+                new ProductBuilder(ProductBuilder.DefaultProduct.TWO).build());
+        assertFalse(standardCommand.equals(cmdWithDiffValues));
     }
 }

--- a/src/test/java/seedu/address/logic/commands/products/AddProductCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/products/AddProductCommandTest.java
@@ -1,0 +1,20 @@
+package seedu.address.logic.commands.products;
+
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalContacts.getTypicalAddressBook;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+
+public class AddProductCommandTest {
+
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void execute() {
+        assertCommandSuccess(new AddProductCommand(), model, AddProductCommand.DUMMY_MESSAGE, model);
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/products/DeleteProductCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/products/DeleteProductCommandTest.java
@@ -1,0 +1,115 @@
+package seedu.address.logic.commands.products;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.CommandTestUtil.showProductAtIndex;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PRODUCT;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PRODUCT;
+import static seedu.address.testutil.TypicalProducts.getTypicalMyCrm;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.products.Product;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for
+ * {@code DeleteProductCommand}.
+ */
+public class DeleteProductCommandTest {
+
+    private Model model;
+
+    @BeforeEach
+    public void init() {
+        model = new ModelManager(getTypicalMyCrm(), new UserPrefs());
+    }
+
+    @Test
+    public void execute_validIndexUnfilteredList_success() {
+        Product productToDelete = model.getFilteredProductList().get(INDEX_FIRST_PRODUCT.getZeroBased());
+        DeleteProductCommand deleteCommand = new DeleteProductCommand(INDEX_FIRST_PRODUCT);
+
+        String expectedMessage = String.format(DeleteProductCommand.MESSAGE_DELETE_PRODUCT_SUCCESS, productToDelete);
+
+        ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.deleteProduct(productToDelete);
+
+        assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidIndexUnfilteredList_throwsCommandException() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredProductList().size() + 1);
+        DeleteProductCommand deleteCommand = new DeleteProductCommand(outOfBoundIndex);
+
+        assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_PRODUCT_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_validIndexFilteredList_success() {
+        showProductAtIndex(model, INDEX_FIRST_PRODUCT);
+
+        Product productToDelete = model.getFilteredProductList().get(INDEX_FIRST_PRODUCT.getZeroBased());
+        DeleteProductCommand deleteCommand = new DeleteProductCommand(INDEX_FIRST_PRODUCT);
+
+        String expectedMessage = String.format(DeleteProductCommand.MESSAGE_DELETE_PRODUCT_SUCCESS, productToDelete);
+
+        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.deleteProduct(productToDelete);
+        showNoProduct(expectedModel);
+
+        assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidIndexFilteredList_throwsCommandException() {
+        showProductAtIndex(model, INDEX_FIRST_PRODUCT);
+
+        Index outOfBoundIndex = INDEX_SECOND_PRODUCT;
+        // ensures that outOfBoundIndex is still in bounds of address book list
+        assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getProductList().size());
+
+        DeleteProductCommand deleteCommand = new DeleteProductCommand(outOfBoundIndex);
+
+        assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_PRODUCT_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void equals() {
+        DeleteProductCommand deleteFirstCommand = new DeleteProductCommand(INDEX_FIRST_PRODUCT);
+        DeleteProductCommand deleteSecondCommand = new DeleteProductCommand(INDEX_SECOND_PRODUCT);
+
+        // same object -> returns true
+        assertTrue(deleteFirstCommand.equals(deleteFirstCommand));
+
+        // same values -> returns true
+        DeleteProductCommand deleteFirstCommandCopy = new DeleteProductCommand(INDEX_FIRST_PRODUCT);
+        assertTrue(deleteFirstCommand.equals(deleteFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(deleteFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(deleteFirstCommand.equals(null));
+
+        // different product -> returns false
+        assertFalse(deleteFirstCommand.equals(deleteSecondCommand));
+    }
+
+    /**
+     * Updates {@code model}'s filtered list to show no product.
+     */
+    private void showNoProduct(Model model) {
+        model.updateFilteredProductList(p -> false);
+
+        assertTrue(model.getFilteredProductList().isEmpty());
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/products/ListProductCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/products/ListProductCommandTest.java
@@ -1,0 +1,39 @@
+package seedu.address.logic.commands.products;
+
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.CommandTestUtil.showProductAtIndex;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PRODUCT;
+import static seedu.address.testutil.TypicalProducts.getTypicalMyCrm;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for ListCommand.
+ */
+public class ListProductCommandTest {
+
+    private Model model;
+    private Model expectedModel;
+
+    @BeforeEach
+    public void setUp() {
+        model = new ModelManager(getTypicalMyCrm(), new UserPrefs());
+        expectedModel = new ModelManager(getTypicalMyCrm(), new UserPrefs());
+    }
+
+    @Test
+    public void execute_listIsNotFiltered_showsSameList() {
+        assertCommandSuccess(new ListProductCommand(), model, ListProductCommand.MESSAGE_SUCCESS, expectedModel);
+    }
+
+    @Test
+    public void execute_listIsFiltered_showsEverything() {
+        showProductAtIndex(model, INDEX_FIRST_PRODUCT);
+        assertCommandSuccess(new ListProductCommand(), model, ListProductCommand.MESSAGE_SUCCESS, expectedModel);
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/MyCrmParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/MyCrmParserTest.java
@@ -26,9 +26,12 @@ import seedu.address.logic.commands.products.AddProductCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.contact.Contact;
 import seedu.address.model.contact.NameContainsKeywordsPredicate;
+import seedu.address.model.products.Product;
 import seedu.address.testutil.ContactBuilder;
 import seedu.address.testutil.ContactUtil;
 import seedu.address.testutil.EditContactDescriptorBuilder;
+import seedu.address.testutil.ProductBuilder;
+import seedu.address.testutil.ProductUtil;
 
 
 public class MyCrmParserTest {
@@ -66,7 +69,9 @@ public class MyCrmParserTest {
 
     @Test
     public void parseCommand_addProduct() throws Exception {
-        assertTrue(parser.parseCommand(AddProductCommand.COMMAND_WORD) instanceof AddProductCommand);
+        Product p = new ProductBuilder().build();
+        AddProductCommand command = (AddProductCommand) parser.parseCommand(ProductUtil.getAddProductCommand(p));
+        assertEquals(new AddProductCommand(p), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/MyCrmParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/MyCrmParserTest.java
@@ -6,6 +6,7 @@ import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_CONTACT;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PRODUCT;
 
 import java.util.Arrays;
 import java.util.List;
@@ -23,6 +24,7 @@ import seedu.address.logic.commands.contacts.EditContactCommand;
 import seedu.address.logic.commands.contacts.EditContactCommand.EditContactDescriptor;
 import seedu.address.logic.commands.contacts.ListContactCommand;
 import seedu.address.logic.commands.products.AddProductCommand;
+import seedu.address.logic.commands.products.DeleteProductCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.contact.Contact;
 import seedu.address.model.contact.NameContainsKeywordsPredicate;
@@ -72,6 +74,13 @@ public class MyCrmParserTest {
         Product p = new ProductBuilder().build();
         AddProductCommand command = (AddProductCommand) parser.parseCommand(ProductUtil.getAddProductCommand(p));
         assertEquals(new AddProductCommand(p), command);
+    }
+
+    @Test
+    public void parseCommand_deleteProduct() throws Exception {
+        DeleteProductCommand command = (DeleteProductCommand) parser.parseCommand(
+                DeleteProductCommand.COMMAND_WORD + " " + INDEX_FIRST_PRODUCT.getOneBased());
+        assertEquals(new DeleteProductCommand(INDEX_FIRST_PRODUCT), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/MyCrmParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/MyCrmParserTest.java
@@ -22,6 +22,7 @@ import seedu.address.logic.commands.contacts.DeleteContactCommand;
 import seedu.address.logic.commands.contacts.EditContactCommand;
 import seedu.address.logic.commands.contacts.EditContactCommand.EditContactDescriptor;
 import seedu.address.logic.commands.contacts.ListContactCommand;
+import seedu.address.logic.commands.products.AddProductCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.contact.Contact;
 import seedu.address.model.contact.NameContainsKeywordsPredicate;
@@ -61,6 +62,11 @@ public class MyCrmParserTest {
         EditContactCommand command = (EditContactCommand) parser.parseCommand(EditContactCommand.COMMAND_WORD + " "
                 + INDEX_FIRST_CONTACT.getOneBased() + " " + ContactUtil.getEditContactDescriptorDetails(descriptor));
         assertEquals(new EditContactCommand(INDEX_FIRST_CONTACT, descriptor), command);
+    }
+
+    @Test
+    public void parseCommand_addProduct() throws Exception {
+        assertTrue(parser.parseCommand(AddProductCommand.COMMAND_WORD) instanceof AddProductCommand);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/products/AddProductCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/products/AddProductCommandParserTest.java
@@ -1,0 +1,32 @@
+package seedu.address.logic.parser.products;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_PRODUCT_NAME_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.PRODUCT_NAME_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_PRODUCT_NAME;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.products.AddProductCommand;
+import seedu.address.model.products.Product;
+
+public class AddProductCommandParserTest {
+    @Test
+    public void parse_validArgs_success() {
+        assertParseSuccess(new AddProductCommandParser(), PRODUCT_NAME_DESC,
+                new AddProductCommand(new Product(VALID_PRODUCT_NAME)));
+    }
+
+    @Test
+    public void parse_invalidArgs_failure() {
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddProductCommand.MESSAGE_USAGE);
+
+        // Lack of name field
+        assertParseFailure(new AddProductCommandParser(), "", expectedMessage);
+
+        // Empty string for name field
+        assertParseFailure(new AddProductCommandParser(), INVALID_PRODUCT_NAME_DESC, expectedMessage);
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/products/AddProductCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/products/AddProductCommandParserTest.java
@@ -2,8 +2,11 @@ package seedu.address.logic.parser.products;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_PRODUCT_NAME_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.PRODUCT_EMPTY_TYPE_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.PRODUCT_NAME_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.PRODUCT_TYPE_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PRODUCT_NAME;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_PRODUCT_TYPE;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
@@ -11,12 +14,18 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.products.AddProductCommand;
 import seedu.address.model.products.Product;
+import seedu.address.model.products.Type;
 
 public class AddProductCommandParserTest {
     @Test
     public void parse_validArgs_success() {
-        assertParseSuccess(new AddProductCommandParser(), PRODUCT_NAME_DESC,
-                new AddProductCommand(new Product(VALID_PRODUCT_NAME)));
+        // Valid arguments: name, type
+        assertParseSuccess(new AddProductCommandParser(), PRODUCT_NAME_DESC + PRODUCT_TYPE_DESC,
+                new AddProductCommand(new Product(VALID_PRODUCT_NAME, VALID_PRODUCT_TYPE)));
+
+        // Valid name, Type empty
+        assertParseSuccess(new AddProductCommandParser(), PRODUCT_NAME_DESC + PRODUCT_EMPTY_TYPE_DESC,
+                new AddProductCommand(new Product(VALID_PRODUCT_NAME, Type.getEmptyType())));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/products/AddProductCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/products/AddProductCommandParserTest.java
@@ -2,11 +2,14 @@ package seedu.address.logic.parser.products;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_PRODUCT_NAME_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.PRODUCT_DESCRIPTION_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.PRODUCT_EMPTY_DESCRIPTION_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.PRODUCT_EMPTY_MANUFACTURER_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.PRODUCT_EMPTY_TYPE_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.PRODUCT_MANUFACTURER_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.PRODUCT_NAME_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.PRODUCT_TYPE_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_PRODUCT_DESCRIPTION;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PRODUCT_MANUFACTURER;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PRODUCT_NAME;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PRODUCT_TYPE;
@@ -16,6 +19,7 @@ import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSucces
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.products.AddProductCommand;
+import seedu.address.model.products.Description;
 import seedu.address.model.products.Manufacturer;
 import seedu.address.model.products.Product;
 import seedu.address.model.products.Type;
@@ -23,22 +27,29 @@ import seedu.address.model.products.Type;
 public class AddProductCommandParserTest {
     @Test
     public void parse_validArgs_success() {
-        // Valid arguments: name, type, manufacturer
+        // Valid arguments: name, type, manufacturer, description
         assertParseSuccess(new AddProductCommandParser(), PRODUCT_NAME_DESC + PRODUCT_TYPE_DESC
-                        + PRODUCT_MANUFACTURER_DESC,
-                new AddProductCommand(new Product(VALID_PRODUCT_NAME, VALID_PRODUCT_TYPE, VALID_PRODUCT_MANUFACTURER)));
+                        + PRODUCT_MANUFACTURER_DESC + PRODUCT_DESCRIPTION_DESC,
+                new AddProductCommand(new Product(VALID_PRODUCT_NAME, VALID_PRODUCT_TYPE, VALID_PRODUCT_MANUFACTURER,
+                        VALID_PRODUCT_DESCRIPTION)));
 
-        // Valid name, empty type, valid manufacturer
+        // Valid name, empty type, valid manufacturer, valid description
         assertParseSuccess(new AddProductCommandParser(), PRODUCT_NAME_DESC + PRODUCT_EMPTY_TYPE_DESC
-                        + PRODUCT_MANUFACTURER_DESC,
+                        + PRODUCT_MANUFACTURER_DESC + PRODUCT_DESCRIPTION_DESC,
                 new AddProductCommand(new Product(VALID_PRODUCT_NAME, Type.getEmptyType(),
-                        VALID_PRODUCT_MANUFACTURER)));
+                        VALID_PRODUCT_MANUFACTURER, VALID_PRODUCT_DESCRIPTION)));
 
-        // Valid name, valid type, empty manufacturer
+        // Valid name, valid type, empty manufacturer, valid description
         assertParseSuccess(new AddProductCommandParser(), PRODUCT_NAME_DESC + PRODUCT_TYPE_DESC
-                        + PRODUCT_EMPTY_MANUFACTURER_DESC,
+                        + PRODUCT_EMPTY_MANUFACTURER_DESC + PRODUCT_DESCRIPTION_DESC,
                 new AddProductCommand(new Product(VALID_PRODUCT_NAME, VALID_PRODUCT_TYPE,
-                        Manufacturer.getEmptyManufacturer())));
+                        Manufacturer.getEmptyManufacturer(), VALID_PRODUCT_DESCRIPTION)));
+
+        // Valid name, valid type, valid manufacturer, empty description
+        assertParseSuccess(new AddProductCommandParser(), PRODUCT_NAME_DESC + PRODUCT_TYPE_DESC
+                        + PRODUCT_MANUFACTURER_DESC + PRODUCT_EMPTY_DESCRIPTION_DESC,
+                new AddProductCommand(new Product(VALID_PRODUCT_NAME, VALID_PRODUCT_TYPE,
+                        VALID_PRODUCT_MANUFACTURER, Description.getEmptyDescription())));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/products/AddProductCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/products/AddProductCommandParserTest.java
@@ -2,9 +2,12 @@ package seedu.address.logic.parser.products;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_PRODUCT_NAME_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.PRODUCT_EMPTY_MANUFACTURER_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.PRODUCT_EMPTY_TYPE_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.PRODUCT_MANUFACTURER_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.PRODUCT_NAME_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.PRODUCT_TYPE_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_PRODUCT_MANUFACTURER;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PRODUCT_NAME;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PRODUCT_TYPE;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
@@ -13,19 +16,29 @@ import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSucces
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.products.AddProductCommand;
+import seedu.address.model.products.Manufacturer;
 import seedu.address.model.products.Product;
 import seedu.address.model.products.Type;
 
 public class AddProductCommandParserTest {
     @Test
     public void parse_validArgs_success() {
-        // Valid arguments: name, type
-        assertParseSuccess(new AddProductCommandParser(), PRODUCT_NAME_DESC + PRODUCT_TYPE_DESC,
-                new AddProductCommand(new Product(VALID_PRODUCT_NAME, VALID_PRODUCT_TYPE)));
+        // Valid arguments: name, type, manufacturer
+        assertParseSuccess(new AddProductCommandParser(), PRODUCT_NAME_DESC + PRODUCT_TYPE_DESC
+                        + PRODUCT_MANUFACTURER_DESC,
+                new AddProductCommand(new Product(VALID_PRODUCT_NAME, VALID_PRODUCT_TYPE, VALID_PRODUCT_MANUFACTURER)));
 
-        // Valid name, Type empty
-        assertParseSuccess(new AddProductCommandParser(), PRODUCT_NAME_DESC + PRODUCT_EMPTY_TYPE_DESC,
-                new AddProductCommand(new Product(VALID_PRODUCT_NAME, Type.getEmptyType())));
+        // Valid name, empty type, valid manufacturer
+        assertParseSuccess(new AddProductCommandParser(), PRODUCT_NAME_DESC + PRODUCT_EMPTY_TYPE_DESC
+                        + PRODUCT_MANUFACTURER_DESC,
+                new AddProductCommand(new Product(VALID_PRODUCT_NAME, Type.getEmptyType(),
+                        VALID_PRODUCT_MANUFACTURER)));
+
+        // Valid name, valid type, empty manufacturer
+        assertParseSuccess(new AddProductCommandParser(), PRODUCT_NAME_DESC + PRODUCT_TYPE_DESC
+                        + PRODUCT_EMPTY_MANUFACTURER_DESC,
+                new AddProductCommand(new Product(VALID_PRODUCT_NAME, VALID_PRODUCT_TYPE,
+                        Manufacturer.getEmptyManufacturer())));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/products/DeleteProductCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/products/DeleteProductCommandParserTest.java
@@ -1,0 +1,26 @@
+package seedu.address.logic.parser.products;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PRODUCT;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.products.DeleteProductCommand;
+
+public class DeleteProductCommandParserTest {
+
+    private DeleteProductCommandParser parser = new DeleteProductCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsDeleteCommand() {
+        assertParseSuccess(parser, "1", new DeleteProductCommand(INDEX_FIRST_PRODUCT));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                DeleteProductCommand.MESSAGE_USAGE));
+    }
+}

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -7,6 +7,7 @@ import static seedu.address.model.Model.PREDICATE_SHOW_ALL_CONTACTS;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalContacts.ALICE;
 import static seedu.address.testutil.TypicalContacts.BENSON;
+import static seedu.address.testutil.TypicalProducts.INTEL_CPU;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -89,8 +90,29 @@ public class ModelManagerTest {
     }
 
     @Test
+    public void hasProduct_nullProduct_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> modelManager.hasProduct(null));
+    }
+
+    @Test
+    public void hasProduct_productNotInMyCrm_returnsFalse() {
+        assertFalse(modelManager.hasProduct(INTEL_CPU));
+    }
+
+    @Test
+    public void hasProduct_productInMyCrm_returnsTrue() {
+        modelManager.addProduct(INTEL_CPU);
+        assertTrue(modelManager.hasProduct(INTEL_CPU));
+    }
+
+    @Test
     public void getFilteredPersonList_modifyList_throwsUnsupportedOperationException() {
         assertThrows(UnsupportedOperationException.class, () -> modelManager.getFilteredContactList().remove(0));
+    }
+
+    @Test
+    public void getFilteredProductList_modifyList_throwsUnsupportedOperationException() {
+        assertThrows(UnsupportedOperationException.class, () -> modelManager.getFilteredProductList().remove(0));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/MyCrmTest.java
+++ b/src/test/java/seedu/address/model/MyCrmTest.java
@@ -8,6 +8,7 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalContacts.ALICE;
 import static seedu.address.testutil.TypicalContacts.getTypicalAddressBook;
+import static seedu.address.testutil.TypicalProducts.INTEL_CPU;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -21,7 +22,9 @@ import javafx.collections.ObservableList;
 import seedu.address.model.contact.Contact;
 import seedu.address.model.contact.exceptions.DuplicateContactException;
 import seedu.address.model.mail.Template;
+import seedu.address.model.products.Product;
 import seedu.address.testutil.ContactBuilder;
+import seedu.address.testutil.ProductBuilder;
 
 public class MyCrmTest {
 
@@ -79,9 +82,40 @@ public class MyCrmTest {
         assertTrue(addressBook.hasPerson(editedAlice));
     }
 
+    //// Product tests
+
+    @Test
+    public void hasProduct_nullProduct_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> addressBook.hasProduct(null));
+    }
+
+    @Test
+    public void hasProduct_productNotInMyCrm_returnsFalse() {
+        assertFalse(addressBook.hasProduct(INTEL_CPU));
+    }
+
+    @Test
+    public void hasProduct_productInMyCrm_returnsTrue() {
+        addressBook.addProduct(INTEL_CPU);
+        assertTrue(addressBook.hasProduct(INTEL_CPU));
+    }
+
+    @Test
+    public void hasProduct_productWithSameIdentityFieldsInMyCrm_returnsTrue() {
+        addressBook.addProduct(INTEL_CPU);
+        Product editedProduct = new ProductBuilder(INTEL_CPU).withManufacturer("Asus").build();
+        assertTrue(addressBook.hasProduct(editedProduct));
+    }
+
+
     @Test
     public void getPersonList_modifyList_throwsUnsupportedOperationException() {
         assertThrows(UnsupportedOperationException.class, () -> addressBook.getPersonList().remove(0));
+    }
+
+    @Test
+    public void getProductList_modifyList_throwsUnsupportedOperationException() {
+        assertThrows(UnsupportedOperationException.class, () -> addressBook.getProductList().remove(0));
     }
 
     /**
@@ -90,6 +124,7 @@ public class MyCrmTest {
     private static class AddressBookStub implements ReadOnlyAddressBook {
         private final ObservableList<Contact> persons = FXCollections.observableArrayList();
         private final ObservableList<Template> templates = FXCollections.observableArrayList();
+        private final ObservableList<Product> products = FXCollections.observableArrayList();
 
         AddressBookStub(Collection<Contact> persons) {
             this.persons.setAll(persons);
@@ -103,6 +138,11 @@ public class MyCrmTest {
         @Override
         public ObservableList<Template> getTemplateList() {
             return templates;
+        }
+
+        @Override
+        public ObservableList<Product> getProductList() {
+            return products;
         }
     }
 

--- a/src/test/java/seedu/address/model/products/DescriptionTest.java
+++ b/src/test/java/seedu/address/model/products/DescriptionTest.java
@@ -1,0 +1,29 @@
+package seedu.address.model.products;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.testutil.ProductBuilder;
+
+public class DescriptionTest {
+    @Test
+    public void equals() {
+        Description description = ProductBuilder.DEFAULT_PRODUCT_ONE_DESCRIPTION;
+
+        assertTrue(description.equals(description));
+
+        Description descriptionCopy = ProductBuilder.DEFAULT_PRODUCT_ONE_DESCRIPTION;
+        assertTrue(description.equals(descriptionCopy));
+
+        assertFalse(description.equals(Description.getEmptyDescription()));
+
+        assertFalse(description.equals(1));
+
+        assertFalse(description.equals(null));
+
+        Description differentDescription = ProductBuilder.DEFAULT_PRODUCT_TWO_DESCRIPTION;
+        assertFalse(description.equals(differentDescription));
+    }
+}

--- a/src/test/java/seedu/address/model/products/ManufacturerTest.java
+++ b/src/test/java/seedu/address/model/products/ManufacturerTest.java
@@ -1,0 +1,27 @@
+package seedu.address.model.products;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+public class ManufacturerTest {
+    @Test
+    public void equals() {
+        Manufacturer manufacturer = Manufacturer.getManufacturer("GPU");
+
+        assertTrue(manufacturer.equals(manufacturer));
+
+        Manufacturer manufacturerCopy = Manufacturer.getManufacturer("GPU");
+        assertTrue(manufacturer.equals(manufacturerCopy));
+
+        assertFalse(manufacturer.equals(Manufacturer.getEmptyManufacturer()));
+
+        assertFalse(manufacturer.equals(1));
+
+        assertFalse(manufacturer.equals(null));
+
+        Manufacturer diffManufacturer = Manufacturer.getManufacturer("CPU");
+        assertFalse(manufacturer.equals(diffManufacturer));
+    }
+}

--- a/src/test/java/seedu/address/model/products/ManufacturerTest.java
+++ b/src/test/java/seedu/address/model/products/ManufacturerTest.java
@@ -5,14 +5,16 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.testutil.ProductBuilder;
+
 public class ManufacturerTest {
     @Test
     public void equals() {
-        Manufacturer manufacturer = Manufacturer.getManufacturer("GPU");
+        Manufacturer manufacturer = ProductBuilder.DEFAULT_PRODUCT_ONE_MANUFACTURER;
 
         assertTrue(manufacturer.equals(manufacturer));
 
-        Manufacturer manufacturerCopy = Manufacturer.getManufacturer("GPU");
+        Manufacturer manufacturerCopy = ProductBuilder.DEFAULT_PRODUCT_ONE_MANUFACTURER;
         assertTrue(manufacturer.equals(manufacturerCopy));
 
         assertFalse(manufacturer.equals(Manufacturer.getEmptyManufacturer()));
@@ -21,7 +23,7 @@ public class ManufacturerTest {
 
         assertFalse(manufacturer.equals(null));
 
-        Manufacturer diffManufacturer = Manufacturer.getManufacturer("CPU");
+        Manufacturer diffManufacturer = ProductBuilder.DEFAULT_PRODUCT_TWO_MANUFACTURER;
         assertFalse(manufacturer.equals(diffManufacturer));
     }
 }

--- a/src/test/java/seedu/address/model/products/ProductNameContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/products/ProductNameContainsKeywordsPredicateTest.java
@@ -1,0 +1,77 @@
+package seedu.address.model.products;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.testutil.ProductBuilder;
+
+public class ProductNameContainsKeywordsPredicateTest {
+
+    @Test
+    public void equals() {
+        List<String> keywordList1 = Collections.singletonList("first");
+        List<String> keywordList2 = Arrays.asList("first", "second");
+
+        ProductNameContainsKeywordsPredicate predicate1 = new ProductNameContainsKeywordsPredicate(keywordList1);
+        ProductNameContainsKeywordsPredicate predicate2 = new ProductNameContainsKeywordsPredicate(keywordList2);
+
+        // same object -> returns true
+        assertTrue(predicate1.equals(predicate1));
+
+        // same values -> returns true
+        ProductNameContainsKeywordsPredicate predicate1Copy = new ProductNameContainsKeywordsPredicate(keywordList1);
+        assertTrue(predicate1.equals(predicate1Copy));
+
+        // different types -> returns false
+        assertFalse(predicate1.equals(1));
+
+        // null -> returns false
+        assertFalse(predicate1.equals(null));
+
+        // different person -> returns false
+        assertFalse(predicate1.equals(predicate2));
+    }
+
+    @Test
+    public void test_nameContainsKeywords_returnsTrue() {
+        // One keyword
+        ProductNameContainsKeywordsPredicate predicate = new ProductNameContainsKeywordsPredicate(
+                Collections.singletonList("Asus"));
+        assertTrue(predicate.test(new ProductBuilder().withName("Asus DUAL-GTX1060-O6G").build()));
+
+        // Multiple keywords
+        predicate = new ProductNameContainsKeywordsPredicate(Arrays.asList("Asus", "DUAL-GTX1060-O6G"));
+        assertTrue(predicate.test(new ProductBuilder().withName("Asus DUAL-GTX1060-O6G").build()));
+
+        // Only one matching keyword
+        predicate = new ProductNameContainsKeywordsPredicate(Arrays.asList("Asus", "DUAL-GTX1060-O6G"));
+        assertTrue(predicate.test(new ProductBuilder().withName("Asus i5-10400F").build()));
+
+        // Mixed-case keywords
+        predicate = new ProductNameContainsKeywordsPredicate(Arrays.asList("asUs", "DUaL-GtX1060-O6g"));
+        assertTrue(predicate.test(new ProductBuilder().withName("Asus DUAL-GTX1060-O6G").build()));
+    }
+
+    @Test
+    public void test_nameDoesNotContainKeywords_returnsFalse() {
+        // Zero keywords
+        ProductNameContainsKeywordsPredicate predicate = new ProductNameContainsKeywordsPredicate(
+                Collections.emptyList());
+        assertFalse(predicate.test(new ProductBuilder().withName("Asus").build()));
+
+        // Non-matching keyword
+        predicate = new ProductNameContainsKeywordsPredicate(Arrays.asList("Intel"));
+        assertFalse(predicate.test(new ProductBuilder().withName("Asus DUAL-GTX1060-O6G").build()));
+
+        // Keywords match phone, email and address, but does not match name
+        predicate = new ProductNameContainsKeywordsPredicate(Arrays.asList("CPU", "Intel", "2.90GHz"));
+        assertFalse(predicate.test(new ProductBuilder().withName("i5-10400F").withType("CPU")
+                .withManufacturer("Intel").withDescription("2.90GHz").build()));
+    }
+}

--- a/src/test/java/seedu/address/model/products/ProductTest.java
+++ b/src/test/java/seedu/address/model/products/ProductTest.java
@@ -24,15 +24,24 @@ public class ProductTest {
         Product differentProduct = new ProductBuilder(ProductBuilder.DefaultProductIndex.TWO).build();
         assertFalse(product.equals(differentProduct));
 
+        Product diffNameProduct = new Product(ProductBuilder.DEFAULT_PRODUCT_TWO_NAME,
+                ProductBuilder.DEFAULT_PRODUCT_ONE_TYPE, ProductBuilder.DEFAULT_PRODUCT_ONE_MANUFACTURER);
+        assertFalse(product.equals(diffNameProduct));
+
         Product diffTypeProduct = new Product(ProductBuilder.DEFAULT_PRODUCT_ONE_NAME,
-                ProductBuilder.DEFAULT_PRODUCT_TWO_TYPE);
+                ProductBuilder.DEFAULT_PRODUCT_TWO_TYPE, ProductBuilder.DEFAULT_PRODUCT_ONE_MANUFACTURER);
         assertFalse(product.equals(diffTypeProduct));
 
-        Product emptyTypeProduct = new Product(ProductBuilder.DEFAULT_PRODUCT_ONE_NAME, Type.getEmptyType());
+        Product emptyTypeProduct = new Product(ProductBuilder.DEFAULT_PRODUCT_ONE_NAME, Type.getEmptyType(),
+                ProductBuilder.DEFAULT_PRODUCT_ONE_MANUFACTURER);
         assertFalse(product.equals(emptyTypeProduct));
 
-        Product diffNameProduct = new Product(ProductBuilder.DEFAULT_PRODUCT_TWO_NAME,
-                ProductBuilder.DEFAULT_PRODUCT_ONE_TYPE);
-        assertFalse(product.equals(diffNameProduct));
+        Product diffManufacturerProduct = new Product(ProductBuilder.DEFAULT_PRODUCT_ONE_NAME,
+                ProductBuilder.DEFAULT_PRODUCT_ONE_TYPE, ProductBuilder.DEFAULT_PRODUCT_TWO_MANUFACTURER);
+        assertFalse(product.equals(diffManufacturerProduct));
+
+        Product emptyManufacturerProduct = new Product(ProductBuilder.DEFAULT_PRODUCT_ONE_NAME,
+                ProductBuilder.DEFAULT_PRODUCT_ONE_TYPE, Manufacturer.getEmptyManufacturer());
+        assertFalse(product.equals(emptyManufacturerProduct));
     }
 }

--- a/src/test/java/seedu/address/model/products/ProductTest.java
+++ b/src/test/java/seedu/address/model/products/ProductTest.java
@@ -2,12 +2,48 @@ package seedu.address.model.products;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.TypicalProducts.ASUS_GPU;
+import static seedu.address.testutil.TypicalProducts.INTEL_CPU;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.address.testutil.ProductBuilder;
 
 public class ProductTest {
+
+    @Test
+    public void isSameProduct() {
+        // same object -> returns true
+        assertTrue(ASUS_GPU.isSameProduct(ASUS_GPU));
+
+        // null -> returns false
+        assertFalse(INTEL_CPU.isSameProduct(null));
+
+        // same name, all other attributes different -> returns true
+        Product editedProduct = new ProductBuilder(ProductBuilder.DefaultProductIndex.ONE)
+                .withType(ProductBuilder.DEFAULT_PRODUCT_TWO_TYPE)
+                .withManufacturer(ProductBuilder.DEFAULT_PRODUCT_TWO_MANUFACTURER)
+                .withDescription(ProductBuilder.DEFAULT_PRODUCT_TWO_DESCRIPTION)
+                .build();
+        assertTrue(new ProductBuilder().build().isSameProduct(editedProduct));
+
+        // different name, all other attributes same -> returns false
+        editedProduct = new ProductBuilder(ProductBuilder.DefaultProductIndex.ONE)
+                .withName(ProductBuilder.DEFAULT_PRODUCT_TWO_NAME).build();
+        assertFalse(new ProductBuilder().build().isSameProduct(editedProduct));
+
+        // name differs in case, all other attributes same -> returns false
+        editedProduct = new ProductBuilder(ProductBuilder.DefaultProductIndex.ONE)
+                .withName(ProductBuilder.DEFAULT_PRODUCT_ONE_NAME.toLowerCase()).build();
+        assertFalse(new ProductBuilder().build().isSameProduct(editedProduct));
+
+        // name has trailing spaces, all other attributes same -> returns false
+        String nameWithTrailingSpaces = ProductBuilder.DEFAULT_PRODUCT_ONE_NAME + " ";
+        editedProduct = new ProductBuilder(ProductBuilder.DefaultProductIndex.ONE)
+                .withName(nameWithTrailingSpaces).build();
+        assertFalse(new ProductBuilder().build().isSameProduct(editedProduct));
+    }
+
     @Test
     public void equals() {
         Product product = new ProductBuilder(ProductBuilder.DefaultProductIndex.ONE).build();

--- a/src/test/java/seedu/address/model/products/ProductTest.java
+++ b/src/test/java/seedu/address/model/products/ProductTest.java
@@ -1,0 +1,38 @@
+package seedu.address.model.products;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.testutil.ProductBuilder;
+
+public class ProductTest {
+    @Test
+    public void equals() {
+        Product product = new ProductBuilder(ProductBuilder.DefaultProductIndex.ONE).build();
+
+        assertTrue(product.equals(product));
+
+        Product productCopy = new ProductBuilder(ProductBuilder.DefaultProductIndex.ONE).build();
+        assertTrue(product.equals(productCopy));
+
+        assertFalse(product.equals(1));
+
+        assertFalse(product.equals(null));
+
+        Product differentProduct = new ProductBuilder(ProductBuilder.DefaultProductIndex.TWO).build();
+        assertFalse(product.equals(differentProduct));
+
+        Product diffTypeProduct = new Product(ProductBuilder.DEFAULT_PRODUCT_ONE_NAME,
+                ProductBuilder.DEFAULT_PRODUCT_TWO_TYPE);
+        assertFalse(product.equals(diffTypeProduct));
+
+        Product emptyTypeProduct = new Product(ProductBuilder.DEFAULT_PRODUCT_ONE_NAME, Type.getEmptyType());
+        assertFalse(product.equals(emptyTypeProduct));
+
+        Product diffNameProduct = new Product(ProductBuilder.DEFAULT_PRODUCT_TWO_NAME,
+                ProductBuilder.DEFAULT_PRODUCT_ONE_TYPE);
+        assertFalse(product.equals(diffNameProduct));
+    }
+}

--- a/src/test/java/seedu/address/model/products/ProductTest.java
+++ b/src/test/java/seedu/address/model/products/ProductTest.java
@@ -25,23 +25,37 @@ public class ProductTest {
         assertFalse(product.equals(differentProduct));
 
         Product diffNameProduct = new Product(ProductBuilder.DEFAULT_PRODUCT_TWO_NAME,
-                ProductBuilder.DEFAULT_PRODUCT_ONE_TYPE, ProductBuilder.DEFAULT_PRODUCT_ONE_MANUFACTURER);
+                ProductBuilder.DEFAULT_PRODUCT_ONE_TYPE, ProductBuilder.DEFAULT_PRODUCT_ONE_MANUFACTURER,
+                ProductBuilder.DEFAULT_PRODUCT_ONE_DESCRIPTION);
         assertFalse(product.equals(diffNameProduct));
 
         Product diffTypeProduct = new Product(ProductBuilder.DEFAULT_PRODUCT_ONE_NAME,
-                ProductBuilder.DEFAULT_PRODUCT_TWO_TYPE, ProductBuilder.DEFAULT_PRODUCT_ONE_MANUFACTURER);
+                ProductBuilder.DEFAULT_PRODUCT_TWO_TYPE, ProductBuilder.DEFAULT_PRODUCT_ONE_MANUFACTURER,
+                ProductBuilder.DEFAULT_PRODUCT_ONE_DESCRIPTION);
         assertFalse(product.equals(diffTypeProduct));
 
         Product emptyTypeProduct = new Product(ProductBuilder.DEFAULT_PRODUCT_ONE_NAME, Type.getEmptyType(),
-                ProductBuilder.DEFAULT_PRODUCT_ONE_MANUFACTURER);
+                ProductBuilder.DEFAULT_PRODUCT_ONE_MANUFACTURER, ProductBuilder.DEFAULT_PRODUCT_ONE_DESCRIPTION);
         assertFalse(product.equals(emptyTypeProduct));
 
         Product diffManufacturerProduct = new Product(ProductBuilder.DEFAULT_PRODUCT_ONE_NAME,
-                ProductBuilder.DEFAULT_PRODUCT_ONE_TYPE, ProductBuilder.DEFAULT_PRODUCT_TWO_MANUFACTURER);
+                ProductBuilder.DEFAULT_PRODUCT_ONE_TYPE, ProductBuilder.DEFAULT_PRODUCT_TWO_MANUFACTURER,
+                ProductBuilder.DEFAULT_PRODUCT_ONE_DESCRIPTION);
         assertFalse(product.equals(diffManufacturerProduct));
 
         Product emptyManufacturerProduct = new Product(ProductBuilder.DEFAULT_PRODUCT_ONE_NAME,
-                ProductBuilder.DEFAULT_PRODUCT_ONE_TYPE, Manufacturer.getEmptyManufacturer());
+                ProductBuilder.DEFAULT_PRODUCT_ONE_TYPE, Manufacturer.getEmptyManufacturer(),
+                ProductBuilder.DEFAULT_PRODUCT_ONE_DESCRIPTION);
         assertFalse(product.equals(emptyManufacturerProduct));
+
+        Product diffDescriptionProduct = new Product(ProductBuilder.DEFAULT_PRODUCT_ONE_NAME,
+                ProductBuilder.DEFAULT_PRODUCT_ONE_TYPE, ProductBuilder.DEFAULT_PRODUCT_ONE_MANUFACTURER,
+                ProductBuilder.DEFAULT_PRODUCT_TWO_DESCRIPTION);
+        assertFalse(product.equals(diffDescriptionProduct));
+
+        Product emptyDescriptionProduct = new Product(ProductBuilder.DEFAULT_PRODUCT_ONE_NAME,
+                ProductBuilder.DEFAULT_PRODUCT_ONE_TYPE, ProductBuilder.DEFAULT_PRODUCT_ONE_MANUFACTURER,
+                Description.getEmptyDescription());
+        assertFalse(product.equals(emptyDescriptionProduct));
     }
 }

--- a/src/test/java/seedu/address/model/products/TypeTest.java
+++ b/src/test/java/seedu/address/model/products/TypeTest.java
@@ -5,14 +5,16 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.testutil.ProductBuilder;
+
 public class TypeTest {
     @Test
     public void equals() {
-        Type type = Type.getType("GPU");
+        Type type = ProductBuilder.DEFAULT_PRODUCT_ONE_TYPE;
 
         assertTrue(type.equals(type));
 
-        Type typeCopy = Type.getType("GPU");
+        Type typeCopy = ProductBuilder.DEFAULT_PRODUCT_ONE_TYPE;
         assertTrue(type.equals(typeCopy));
 
         assertFalse(type.equals(Type.getEmptyType()));
@@ -21,7 +23,7 @@ public class TypeTest {
 
         assertFalse(type.equals(null));
 
-        Type differentType = Type.getType("CPU");
+        Type differentType = ProductBuilder.DEFAULT_PRODUCT_TWO_TYPE;
         assertFalse(type.equals(differentType));
     }
 }

--- a/src/test/java/seedu/address/model/products/TypeTest.java
+++ b/src/test/java/seedu/address/model/products/TypeTest.java
@@ -1,0 +1,27 @@
+package seedu.address.model.products;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+public class TypeTest {
+    @Test
+    public void equals() {
+        Type type = Type.getType("GPU");
+
+        assertTrue(type.equals(type));
+
+        Type typeCopy = Type.getType("GPU");
+        assertTrue(type.equals(typeCopy));
+
+        assertFalse(type.equals(Type.getEmptyType()));
+
+        assertFalse(type.equals(1));
+
+        assertFalse(type.equals(null));
+
+        Type differentType = Type.getType("CPU");
+        assertFalse(type.equals(differentType));
+    }
+}

--- a/src/test/java/seedu/address/model/products/UniqueProductListTest.java
+++ b/src/test/java/seedu/address/model/products/UniqueProductListTest.java
@@ -1,0 +1,181 @@
+package seedu.address.model.products;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.TypicalProducts.ASUS_GPU;
+import static seedu.address.testutil.TypicalProducts.INTEL_CPU;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.products.exceptions.DuplicateProductException;
+import seedu.address.model.products.exceptions.ProductNotFoundException;
+import seedu.address.testutil.ProductBuilder;
+
+public class UniqueProductListTest {
+
+    private UniqueProductList uniqueProductList;
+
+    @BeforeEach
+    public void init() {
+        this.uniqueProductList = new UniqueProductList();
+    }
+
+    @Test
+    public void contains_nullProduct_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> uniqueProductList.contains(null));
+    }
+
+    @Test
+    public void contains_productNotInList_returnsFalse() {
+        assertFalse(uniqueProductList.contains(ASUS_GPU));
+    }
+
+    @Test
+    public void contains_productInList_returnsTrue() {
+        uniqueProductList.add(ASUS_GPU);
+        assertTrue(uniqueProductList.contains(ASUS_GPU));
+    }
+
+    @Test
+    public void contains_productWithSameNameInList_returnsTrue() {
+        Product p = new Product(ProductBuilder.DEFAULT_PRODUCT_ONE_NAME, Type.getEmptyType(),
+                Manufacturer.getEmptyManufacturer(), Description.getEmptyDescription());
+        uniqueProductList.add(p);
+        assertTrue(uniqueProductList.contains(ASUS_GPU));
+    }
+
+    @Test
+    public void add_nullProduct_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> uniqueProductList.add(null));
+    }
+
+    @Test
+    public void add_duplicateProduct_throwsDuplicateProductException() {
+        uniqueProductList.add(ASUS_GPU);
+        assertThrows(DuplicateProductException.class, () -> uniqueProductList.add(ASUS_GPU));
+    }
+
+    @Test
+    public void setProduct_nullTargetProduct_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> uniqueProductList.setProduct(null, ASUS_GPU));
+    }
+
+    @Test
+    public void setProduct_nullEditedProduct_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> uniqueProductList.setProduct(ASUS_GPU, null));
+    }
+
+    @Test
+    public void setProduct_targetProductNotInList_throwsProductNotFoundException() {
+        assertThrows(ProductNotFoundException.class, () -> uniqueProductList.setProduct(ASUS_GPU,
+                ASUS_GPU));
+    }
+
+    @Test
+    public void setProduct_editedProductIsSameProduct_success() {
+        uniqueProductList.add(ASUS_GPU);
+        uniqueProductList.setProduct(ASUS_GPU, ASUS_GPU);
+
+        UniqueProductList expectedUniqueProductList = new UniqueProductList();
+        expectedUniqueProductList.add(ASUS_GPU);
+        assertEquals(expectedUniqueProductList, uniqueProductList);
+    }
+
+    @Test
+    public void setProduct_editedProductHasSameName_success() {
+        uniqueProductList.add(ASUS_GPU);
+        Product editProduct = new ProductBuilder().withType(ProductBuilder.DEFAULT_PRODUCT_TWO_TYPE.toString()).build();
+        uniqueProductList.setProduct(ASUS_GPU, editProduct);
+
+        UniqueProductList expectedUniqueProductList = new UniqueProductList();
+        expectedUniqueProductList.add(editProduct);
+        assertEquals(expectedUniqueProductList, uniqueProductList);
+    }
+
+    @Test
+    public void setProduct_editedProductHasDifferentName_success() {
+        uniqueProductList.add(ASUS_GPU);
+        uniqueProductList.setProduct(ASUS_GPU, INTEL_CPU);
+
+        UniqueProductList expectedUniqueProductList = new UniqueProductList();
+        expectedUniqueProductList.add(INTEL_CPU);
+        assertEquals(expectedUniqueProductList, uniqueProductList);
+    }
+
+    @Test
+    public void setProduct_editedProductHasNonUniqueName_throwsDuplicateProductException() {
+        uniqueProductList.add(ASUS_GPU);
+        uniqueProductList.add(INTEL_CPU);
+        assertThrows(DuplicateProductException.class, () -> uniqueProductList.setProduct(ASUS_GPU,
+                INTEL_CPU));
+    }
+
+    @Test
+    public void remove_nullProduct_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> uniqueProductList.remove(null));
+    }
+
+    @Test
+    public void remove_productDoesNotExist_throwsProductNotFoundException() {
+        assertThrows(ProductNotFoundException.class, () -> uniqueProductList.remove(ASUS_GPU));
+    }
+
+    @Test
+    public void remove_existingProduct_removesProduct() {
+        uniqueProductList.add(ASUS_GPU);
+        uniqueProductList.remove(ASUS_GPU);
+
+        UniqueProductList expectedUniqueProductList = new UniqueProductList();
+        assertEquals(expectedUniqueProductList, uniqueProductList);
+    }
+
+    @Test
+    public void setProducts_nullUniqueProductList_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> uniqueProductList.setProducts((UniqueProductList) null));
+    }
+
+    @Test
+    public void setProducts_uniqueProductList_replacesOwnListWithProvidedUniqueProductList() {
+        uniqueProductList.add(ASUS_GPU);
+
+        UniqueProductList expectedUniqueProductList = new UniqueProductList();
+        expectedUniqueProductList.add(INTEL_CPU);
+        uniqueProductList.setProducts(expectedUniqueProductList);
+        assertEquals(expectedUniqueProductList, uniqueProductList);
+    }
+
+    @Test
+    public void setProducts_nullList_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> uniqueProductList.setProducts((List<Product>) null));
+    }
+
+    @Test
+    public void setProducts_list_replacesOwnListWithProvidedList() {
+        uniqueProductList.add(ASUS_GPU);
+        List<Product> personList = Collections.singletonList(INTEL_CPU);
+        uniqueProductList.setProducts(personList);
+
+        UniqueProductList expectedUniqueProductList = new UniqueProductList();
+        expectedUniqueProductList.add(INTEL_CPU);
+        assertEquals(expectedUniqueProductList, uniqueProductList);
+    }
+
+    @Test
+    public void setProducts_listWithDuplicateProducts_throwsDuplicateProductException() {
+        List<Product> listWithDuplicateProducts = Arrays.asList(ASUS_GPU, ASUS_GPU);
+        assertThrows(DuplicateProductException.class, () -> uniqueProductList.setProducts(listWithDuplicateProducts));
+    }
+
+    @Test
+    public void asUnmodifiableObservableList_modifyList_throwsUnsupportedOperationException() {
+        assertThrows(UnsupportedOperationException.class, ()
+            -> uniqueProductList.asUnmodifiableObservableList().remove(0));
+    }
+}

--- a/src/test/java/seedu/address/testutil/ProductBuilder.java
+++ b/src/test/java/seedu/address/testutil/ProductBuilder.java
@@ -1,0 +1,38 @@
+package seedu.address.testutil;
+
+import seedu.address.model.products.Product;
+
+public class ProductBuilder {
+
+    public static final String DEFAULT_PRODUCT_ONE_NAME = "Intel i5-10400F";
+
+    public static final String DEFAULT_PRODUCT_TWO_NAME = "Asus DUAL-GTX1060-O6G";
+
+    private Product toBuild;
+
+    /**
+     * Create a product builder with index of default product.
+     */
+    public ProductBuilder(DefaultProduct index) {
+        switch (index) {
+        case ONE:
+            this.toBuild = new Product(DEFAULT_PRODUCT_ONE_NAME);
+            break;
+        case TWO:
+            this.toBuild = new Product(DEFAULT_PRODUCT_TWO_NAME);
+            break;
+        default:
+            assert false : "Enum not implemented";
+        }
+    }
+
+    public ProductBuilder() {
+        this(DefaultProduct.ONE);
+    }
+
+    public Product build() {
+        return toBuild;
+    }
+
+    public enum DefaultProduct { ONE, TWO };
+}

--- a/src/test/java/seedu/address/testutil/ProductBuilder.java
+++ b/src/test/java/seedu/address/testutil/ProductBuilder.java
@@ -1,5 +1,6 @@
 package seedu.address.testutil;
 
+import seedu.address.model.products.Description;
 import seedu.address.model.products.Manufacturer;
 import seedu.address.model.products.Product;
 import seedu.address.model.products.Type;
@@ -9,10 +10,13 @@ public class ProductBuilder {
     public static final String DEFAULT_PRODUCT_ONE_NAME = "Intel i5-10400F";
     public static final Type DEFAULT_PRODUCT_ONE_TYPE = Type.getType("CPU");
     public static final Manufacturer DEFAULT_PRODUCT_ONE_MANUFACTURER = Manufacturer.getManufacturer("Intel");
+    public static final Description DEFAULT_PRODUCT_ONE_DESCRIPTION = Description.getDescription("2.90GHz");
 
     public static final String DEFAULT_PRODUCT_TWO_NAME = "Asus DUAL-GTX1060-O6G";
     public static final Type DEFAULT_PRODUCT_TWO_TYPE = Type.getType("GPU");
     public static final Manufacturer DEFAULT_PRODUCT_TWO_MANUFACTURER = Manufacturer.getManufacturer("Asus");
+    public static final Description DEFAULT_PRODUCT_TWO_DESCRIPTION = Description.getDescription("Video output "
+            + "interface: DisplayPort, HDMI");
 
     private Product toBuild;
 
@@ -23,11 +27,11 @@ public class ProductBuilder {
         switch (index) {
         case ONE:
             this.toBuild = new Product(DEFAULT_PRODUCT_ONE_NAME, DEFAULT_PRODUCT_ONE_TYPE,
-                    DEFAULT_PRODUCT_ONE_MANUFACTURER);
+                    DEFAULT_PRODUCT_ONE_MANUFACTURER, DEFAULT_PRODUCT_ONE_DESCRIPTION);
             break;
         case TWO:
             this.toBuild = new Product(DEFAULT_PRODUCT_TWO_NAME, DEFAULT_PRODUCT_TWO_TYPE,
-                    DEFAULT_PRODUCT_TWO_MANUFACTURER);
+                    DEFAULT_PRODUCT_TWO_MANUFACTURER, DEFAULT_PRODUCT_TWO_DESCRIPTION);
             break;
         default:
             assert false : "Enum not implemented";

--- a/src/test/java/seedu/address/testutil/ProductBuilder.java
+++ b/src/test/java/seedu/address/testutil/ProductBuilder.java
@@ -1,5 +1,6 @@
 package seedu.address.testutil;
 
+import seedu.address.model.products.Manufacturer;
 import seedu.address.model.products.Product;
 import seedu.address.model.products.Type;
 
@@ -7,9 +8,11 @@ public class ProductBuilder {
 
     public static final String DEFAULT_PRODUCT_ONE_NAME = "Intel i5-10400F";
     public static final Type DEFAULT_PRODUCT_ONE_TYPE = Type.getType("CPU");
+    public static final Manufacturer DEFAULT_PRODUCT_ONE_MANUFACTURER = Manufacturer.getManufacturer("Intel");
 
     public static final String DEFAULT_PRODUCT_TWO_NAME = "Asus DUAL-GTX1060-O6G";
     public static final Type DEFAULT_PRODUCT_TWO_TYPE = Type.getType("GPU");
+    public static final Manufacturer DEFAULT_PRODUCT_TWO_MANUFACTURER = Manufacturer.getManufacturer("Asus");
 
     private Product toBuild;
 
@@ -19,10 +22,12 @@ public class ProductBuilder {
     public ProductBuilder(DefaultProductIndex index) {
         switch (index) {
         case ONE:
-            this.toBuild = new Product(DEFAULT_PRODUCT_ONE_NAME, DEFAULT_PRODUCT_ONE_TYPE);
+            this.toBuild = new Product(DEFAULT_PRODUCT_ONE_NAME, DEFAULT_PRODUCT_ONE_TYPE,
+                    DEFAULT_PRODUCT_ONE_MANUFACTURER);
             break;
         case TWO:
-            this.toBuild = new Product(DEFAULT_PRODUCT_TWO_NAME, DEFAULT_PRODUCT_TWO_TYPE);
+            this.toBuild = new Product(DEFAULT_PRODUCT_TWO_NAME, DEFAULT_PRODUCT_TWO_TYPE,
+                    DEFAULT_PRODUCT_TWO_MANUFACTURER);
             break;
         default:
             assert false : "Enum not implemented";

--- a/src/test/java/seedu/address/testutil/ProductBuilder.java
+++ b/src/test/java/seedu/address/testutil/ProductBuilder.java
@@ -1,25 +1,28 @@
 package seedu.address.testutil;
 
 import seedu.address.model.products.Product;
+import seedu.address.model.products.Type;
 
 public class ProductBuilder {
 
     public static final String DEFAULT_PRODUCT_ONE_NAME = "Intel i5-10400F";
+    public static final Type DEFAULT_PRODUCT_ONE_TYPE = Type.getType("CPU");
 
     public static final String DEFAULT_PRODUCT_TWO_NAME = "Asus DUAL-GTX1060-O6G";
+    public static final Type DEFAULT_PRODUCT_TWO_TYPE = Type.getType("GPU");
 
     private Product toBuild;
 
     /**
      * Create a product builder with index of default product.
      */
-    public ProductBuilder(DefaultProduct index) {
+    public ProductBuilder(DefaultProductIndex index) {
         switch (index) {
         case ONE:
-            this.toBuild = new Product(DEFAULT_PRODUCT_ONE_NAME);
+            this.toBuild = new Product(DEFAULT_PRODUCT_ONE_NAME, DEFAULT_PRODUCT_ONE_TYPE);
             break;
         case TWO:
-            this.toBuild = new Product(DEFAULT_PRODUCT_TWO_NAME);
+            this.toBuild = new Product(DEFAULT_PRODUCT_TWO_NAME, DEFAULT_PRODUCT_TWO_TYPE);
             break;
         default:
             assert false : "Enum not implemented";
@@ -27,12 +30,12 @@ public class ProductBuilder {
     }
 
     public ProductBuilder() {
-        this(DefaultProduct.ONE);
+        this(DefaultProductIndex.ONE);
     }
 
     public Product build() {
         return toBuild;
     }
 
-    public enum DefaultProduct { ONE, TWO };
+    public enum DefaultProductIndex { ONE, TWO };
 }

--- a/src/test/java/seedu/address/testutil/ProductBuilder.java
+++ b/src/test/java/seedu/address/testutil/ProductBuilder.java
@@ -18,6 +18,13 @@ public class ProductBuilder {
     public static final Description DEFAULT_PRODUCT_TWO_DESCRIPTION = Description.getDescription("Video output "
             + "interface: DisplayPort, HDMI");
 
+    public static final String DEFAULT_PRODUCT_THREE_NAME = "SAMSUNG 980 PRO 1TB SSD";
+    public static final Type DEFAULT_PRODUCT_THREE_TYPE = Type.getType("Hard disk");
+    public static final Manufacturer DEFAULT_PRODUCT_THREE_MANUFACTURER = Manufacturer.getManufacturer("SAMSUNG");
+    public static final Description DEFAULT_PRODUCT_THREE_DESCRIPTION = Description.getDescription(
+            "Connectivity technology: SATA");
+
+
     private String name;
     private Type type;
     private Manufacturer manufacturer;
@@ -39,6 +46,12 @@ public class ProductBuilder {
             this.type = DEFAULT_PRODUCT_TWO_TYPE;
             this.manufacturer = DEFAULT_PRODUCT_TWO_MANUFACTURER;
             this.description = DEFAULT_PRODUCT_TWO_DESCRIPTION;
+            break;
+        case THREE:
+            this.name = DEFAULT_PRODUCT_THREE_NAME;
+            this.type = DEFAULT_PRODUCT_THREE_TYPE;
+            this.manufacturer = DEFAULT_PRODUCT_THREE_MANUFACTURER;
+            this.description = DEFAULT_PRODUCT_THREE_DESCRIPTION;
             break;
         default:
             assert false : "Enum not implemented";
@@ -119,5 +132,5 @@ public class ProductBuilder {
         return new Product(name, type, manufacturer, description);
     }
 
-    public enum DefaultProductIndex { ONE, TWO };
+    public enum DefaultProductIndex { ONE, TWO, THREE };
 }

--- a/src/test/java/seedu/address/testutil/ProductBuilder.java
+++ b/src/test/java/seedu/address/testutil/ProductBuilder.java
@@ -18,7 +18,10 @@ public class ProductBuilder {
     public static final Description DEFAULT_PRODUCT_TWO_DESCRIPTION = Description.getDescription("Video output "
             + "interface: DisplayPort, HDMI");
 
-    private Product toBuild;
+    private String name;
+    private Type type;
+    private Manufacturer manufacturer;
+    private Description description;
 
     /**
      * Create a product builder with index of default product.
@@ -26,24 +29,94 @@ public class ProductBuilder {
     public ProductBuilder(DefaultProductIndex index) {
         switch (index) {
         case ONE:
-            this.toBuild = new Product(DEFAULT_PRODUCT_ONE_NAME, DEFAULT_PRODUCT_ONE_TYPE,
-                    DEFAULT_PRODUCT_ONE_MANUFACTURER, DEFAULT_PRODUCT_ONE_DESCRIPTION);
+            this.name = DEFAULT_PRODUCT_ONE_NAME;
+            this.type = DEFAULT_PRODUCT_ONE_TYPE;
+            this.manufacturer = DEFAULT_PRODUCT_ONE_MANUFACTURER;
+            this.description = DEFAULT_PRODUCT_ONE_DESCRIPTION;
             break;
         case TWO:
-            this.toBuild = new Product(DEFAULT_PRODUCT_TWO_NAME, DEFAULT_PRODUCT_TWO_TYPE,
-                    DEFAULT_PRODUCT_TWO_MANUFACTURER, DEFAULT_PRODUCT_TWO_DESCRIPTION);
+            this.name = DEFAULT_PRODUCT_TWO_NAME;
+            this.type = DEFAULT_PRODUCT_TWO_TYPE;
+            this.manufacturer = DEFAULT_PRODUCT_TWO_MANUFACTURER;
+            this.description = DEFAULT_PRODUCT_TWO_DESCRIPTION;
             break;
         default:
             assert false : "Enum not implemented";
         }
     }
 
+    /**
+     * Creates a product builder with provided product.
+     */
+    public ProductBuilder(Product product) {
+        this.name = product.getName();
+        this.type = product.getType();
+        this.manufacturer = product.getManufacturer();
+        this.description = product.getDescription();
+    }
+
     public ProductBuilder() {
         this(DefaultProductIndex.ONE);
     }
 
+    /**
+     * Sets name field to given name.
+     */
+    public ProductBuilder withName(String productName) {
+        this.name = productName;
+        return this;
+    }
+
+    /**
+     * Initializes type field with given string.
+     */
+    public ProductBuilder withType(String type) {
+        this.type = Type.getType(type);
+        return this;
+    }
+
+    /**
+     * Sets type field to given type.
+     */
+    public ProductBuilder withType(Type type) {
+        this.type = type;
+        return this;
+    }
+
+    /**
+     * Initializes manufacturer field with given manufacturer.
+     */
+    public ProductBuilder withManufacturer(String manufacturer) {
+        this.manufacturer = Manufacturer.getManufacturer(manufacturer);
+        return this;
+    }
+
+    /**
+     * Sets manufacturer field to given manufacturer.
+     */
+    public ProductBuilder withManufacturer(Manufacturer manufacturer) {
+        this.manufacturer = manufacturer;
+        return this;
+    }
+
+    /**
+     * Initializes description field with given description.
+     */
+    public ProductBuilder withDescription(String description) {
+        this.description = Description.getDescription(description);
+        return this;
+    }
+
+    /**
+     * Sets description field to given description.
+     */
+    public ProductBuilder withDescription(Description description) {
+        this.description = description;
+        return this;
+    }
+
     public Product build() {
-        return toBuild;
+        return new Product(name, type, manufacturer, description);
     }
 
     public enum DefaultProductIndex { ONE, TWO };

--- a/src/test/java/seedu/address/testutil/ProductUtil.java
+++ b/src/test/java/seedu/address/testutil/ProductUtil.java
@@ -2,16 +2,17 @@ package seedu.address.testutil;
 
 import static seedu.address.logic.commands.products.AddProductCommand.COMMAND_WORD;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PRODUCT_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PRODUCT_TYPE;
 
 import seedu.address.model.products.Product;
 
 public class ProductUtil {
 
-
     /**
      * Get Add product command string for the given product.
      */
     public static String getAddProductCommand(Product product) {
-        return COMMAND_WORD + " " + PREFIX_PRODUCT_NAME + product.getName();
+        return COMMAND_WORD + " " + PREFIX_PRODUCT_NAME + product.getName()
+                + (product.hasType() ? " " + PREFIX_PRODUCT_TYPE + product.getType().toString() : "");
     }
 }

--- a/src/test/java/seedu/address/testutil/ProductUtil.java
+++ b/src/test/java/seedu/address/testutil/ProductUtil.java
@@ -1,6 +1,7 @@
 package seedu.address.testutil;
 
 import static seedu.address.logic.commands.products.AddProductCommand.COMMAND_WORD;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PRODUCT_MANUFACTURER;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PRODUCT_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PRODUCT_TYPE;
 
@@ -13,6 +14,9 @@ public class ProductUtil {
      */
     public static String getAddProductCommand(Product product) {
         return COMMAND_WORD + " " + PREFIX_PRODUCT_NAME + product.getName()
-                + (product.hasType() ? " " + PREFIX_PRODUCT_TYPE + product.getType().toString() : "");
+                + (product.hasType() ? " " + PREFIX_PRODUCT_TYPE + product.getType().toString() : "")
+                + (product.hasManufacturer()
+                    ? " " + PREFIX_PRODUCT_MANUFACTURER + product.getManufacturer().toString()
+                    : "");
     }
 }

--- a/src/test/java/seedu/address/testutil/ProductUtil.java
+++ b/src/test/java/seedu/address/testutil/ProductUtil.java
@@ -1,0 +1,17 @@
+package seedu.address.testutil;
+
+import static seedu.address.logic.commands.products.AddProductCommand.COMMAND_WORD;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PRODUCT_NAME;
+
+import seedu.address.model.products.Product;
+
+public class ProductUtil {
+
+
+    /**
+     * Get Add product command string for the given product.
+     */
+    public static String getAddProductCommand(Product product) {
+        return COMMAND_WORD + " " + PREFIX_PRODUCT_NAME + product.getName();
+    }
+}

--- a/src/test/java/seedu/address/testutil/ProductUtil.java
+++ b/src/test/java/seedu/address/testutil/ProductUtil.java
@@ -1,6 +1,7 @@
 package seedu.address.testutil;
 
 import static seedu.address.logic.commands.products.AddProductCommand.COMMAND_WORD;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PRODUCT_DESCRIPTION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PRODUCT_MANUFACTURER;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PRODUCT_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PRODUCT_TYPE;
@@ -17,6 +18,9 @@ public class ProductUtil {
                 + (product.hasType() ? " " + PREFIX_PRODUCT_TYPE + product.getType().toString() : "")
                 + (product.hasManufacturer()
                     ? " " + PREFIX_PRODUCT_MANUFACTURER + product.getManufacturer().toString()
+                    : "")
+                + (product.hasDescription()
+                    ? " " + PREFIX_PRODUCT_DESCRIPTION + product.getDescription().toString()
                     : "");
     }
 }

--- a/src/test/java/seedu/address/testutil/TypicalIndexes.java
+++ b/src/test/java/seedu/address/testutil/TypicalIndexes.java
@@ -12,4 +12,7 @@ public class TypicalIndexes {
 
     public static final Index INDEX_FIRST_TEMPLATE = Index.fromOneBased(1);
     public static final Index INDEX_SECOND_TEMPLATE = Index.fromOneBased(2);
+
+    public static final Index INDEX_FIRST_PRODUCT = Index.fromOneBased(1);
+    public static final Index INDEX_SECOND_PRODUCT = Index.fromOneBased(2);
 }

--- a/src/test/java/seedu/address/testutil/TypicalProducts.java
+++ b/src/test/java/seedu/address/testutil/TypicalProducts.java
@@ -9,6 +9,7 @@ import seedu.address.model.products.Product;
 public class TypicalProducts {
     public static final Product ASUS_GPU = new ProductBuilder(ProductBuilder.DefaultProductIndex.ONE).build();
     public static final Product INTEL_CPU = new ProductBuilder(ProductBuilder.DefaultProductIndex.TWO).build();
+    public static final Product SAMSUNG_SSD = new ProductBuilder(ProductBuilder.DefaultProductIndex.THREE).build();
 
     /**
      * Returns an {@code MyCrm} with all the typical products.
@@ -22,6 +23,6 @@ public class TypicalProducts {
     }
 
     public static ArrayList<Product> getTypicalProducts() {
-        return new ArrayList<>(Arrays.asList(ASUS_GPU, INTEL_CPU));
+        return new ArrayList<>(Arrays.asList(ASUS_GPU, INTEL_CPU, SAMSUNG_SSD));
     }
 }

--- a/src/test/java/seedu/address/testutil/TypicalProducts.java
+++ b/src/test/java/seedu/address/testutil/TypicalProducts.java
@@ -1,0 +1,27 @@
+package seedu.address.testutil;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import seedu.address.model.MyCrm;
+import seedu.address.model.products.Product;
+
+public class TypicalProducts {
+    public static final Product ASUS_GPU = new ProductBuilder(ProductBuilder.DefaultProductIndex.ONE).build();
+    public static final Product INTEL_CPU = new ProductBuilder(ProductBuilder.DefaultProductIndex.TWO).build();
+
+    /**
+     * Returns an {@code MyCrm} with all the typical products.
+     */
+    public static MyCrm getTypicalMyCrm() {
+        MyCrm myCrm = new MyCrm();
+        for (Product p : getTypicalProducts()) {
+            myCrm.addProduct(p);
+        }
+        return myCrm;
+    }
+
+    public static ArrayList<Product> getTypicalProducts() {
+        return new ArrayList<>(Arrays.asList(ASUS_GPU, INTEL_CPU));
+    }
+}


### PR DESCRIPTION
#### Other changes:
main:
Model: Add `Product`.
Ui: Add product list panel.

test:
Add tests to test newly added classes.

#### Note:
* The UI part is **not completed**: product panel will not be shown for product commands. Now main window is keeping track of 4-5 booleans to decide which panel to show. I did not add a corresponding boolean for product commmands. I would substitude the booleans with enums in next merge.
* To make this commit a working solution (without using enums), let's add code in `MainWindow`, `CommandResult` and product commands to match `Contact/Template/Job`.