### PR TITLE
Fix editContactCommand Bug.

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -294,6 +294,7 @@ Format: `hideContact INDEX`
 
 * `hideContact` will add a tag `hidden` to those being hidden.
 * Cannot invoke `hideContact` **again** to those being hidden.
+* So far hiding a specific contact will not affect job card.
 
 Example:
 

--- a/src/main/java/seedu/mycrm/logic/commands/contacts/EditContactCommand.java
+++ b/src/main/java/seedu/mycrm/logic/commands/contacts/EditContactCommand.java
@@ -115,8 +115,9 @@ public class EditContactCommand extends Command {
         Email updatedEmail = editContactDescriptor.getEmail().orElse(contactToEdit.getEmail());
         Address updatedAddress = editContactDescriptor.getAddress().orElse(contactToEdit.getAddress());
         Set<Tag> updatedTags = editContactDescriptor.getTags().orElse(contactToEdit.getTags());
+        boolean isHidden = contactToEdit.checkIsHidden();
 
-        return new Contact(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedTags);
+        return new Contact(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedTags, isHidden);
     }
 
     @Override


### PR DESCRIPTION
A tester pointed out that if a user edits a contact, the tag for visability disappears.

This bug has been fixed.