### PR TITLE
Update testcases for contacts

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -197,6 +197,12 @@ Then create a contact using the new name, phone, email and address.
 
 ![](images/AddContactSequenceDiagram.png)
 
+### Editing a Contact
+
+### Deleting a Contact
+
+### Finding a Contact
+
 ### Hiding a Contact
 
 #### Implementation
@@ -204,6 +210,8 @@ Then create a contact using the new name, phone, email and address.
 The Hiding a Contact mechanism follows the `EditCommand` mechanism in `AddressBook`. It hides a specific contact
 which is visible only when user types the command `listContact -a`. Hidden contact will be tagged as `Hidden`. The
 Edited contact created is stored internally using `UniqueContactList` inside the `MyCrm` object
+
+### Undoing Hiding a Contact
 
 ### Listing Contacts
 

--- a/src/main/java/seedu/mycrm/logic/parser/contacts/AddContactCommandParser.java
+++ b/src/main/java/seedu/mycrm/logic/parser/contacts/AddContactCommandParser.java
@@ -72,8 +72,6 @@ public class AddContactCommandParser implements Parser<AddContactCommand> {
                 ? Address.getEmptyAddress()
                 : Address.getAddress(addressWrapper.get());
 
-        System.out.println(address.toString());
-
         if (phone.isEmpty() && email.isEmpty() && address.isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     AddContactCommand.MESSAGE_AT_LEAST_ONE_COMPONENT));

--- a/src/main/java/seedu/mycrm/logic/parser/contacts/AddContactCommandParser.java
+++ b/src/main/java/seedu/mycrm/logic/parser/contacts/AddContactCommandParser.java
@@ -25,6 +25,7 @@ import seedu.mycrm.model.contact.Phone;
 import seedu.mycrm.model.contact.tag.Tag;
 
 public class AddContactCommandParser implements Parser<AddContactCommand> {
+    private static final String EMPTY_PREFIX = "EMPTY";
     /**
      * Parses the given {@code String} of arguments in the context of the {@code AddContactCommand}
      * and returns a {@code AddContactCommand} object for execution.
@@ -56,18 +57,18 @@ public class AddContactCommandParser implements Parser<AddContactCommand> {
 
         Optional<String> phoneWrapper = argMultimap.getValue(PREFIX_PHONE);
         Phone phone;
-        phone = phoneWrapper.orElse("").equals("")
+        phone = phoneWrapper.orElse(EMPTY_PREFIX).equals(EMPTY_PREFIX)
                 ? Phone.getEmptyPhone()
                 : Phone.getPhone(phoneWrapper.get());
 
         Optional<String> emailWrapper = argMultimap.getValue(PREFIX_EMAIL);
-        Email email = emailWrapper.orElse("").equals("")
+        Email email = emailWrapper.orElse(EMPTY_PREFIX).equals(EMPTY_PREFIX)
                 ? Email.getEmptyEmail()
                 : Email.getEmail(emailWrapper.get());
 
 
         Optional<String> addressWrapper = argMultimap.getValue(PREFIX_ADDRESS);
-        Address address = addressWrapper.orElse("").equals("")
+        Address address = addressWrapper.orElse(EMPTY_PREFIX).equals(EMPTY_PREFIX)
                 ? Address.getEmptyAddress()
                 : Address.getAddress(addressWrapper.get());
 

--- a/src/main/java/seedu/mycrm/logic/parser/contacts/AddContactCommandParser.java
+++ b/src/main/java/seedu/mycrm/logic/parser/contacts/AddContactCommandParser.java
@@ -71,7 +71,9 @@ public class AddContactCommandParser implements Parser<AddContactCommand> {
                 ? Address.getEmptyAddress()
                 : Address.getAddress(addressWrapper.get());
 
-        if (phoneWrapper.isEmpty() && emailWrapper.isEmpty() && addressWrapper.isEmpty()) {
+        System.out.println(address.toString());
+
+        if (phone.isEmpty() && email.isEmpty() && address.isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     AddContactCommand.MESSAGE_AT_LEAST_ONE_COMPONENT));
         }

--- a/src/main/java/seedu/mycrm/model/ModelManager.java
+++ b/src/main/java/seedu/mycrm/model/ModelManager.java
@@ -254,8 +254,8 @@ public class ModelManager implements Model {
     //=========== Filtered Contact List Accessors =============================================================
 
     /**
-     * Returns an unmodifiable view of the list of {@code Contact} backed by the internal list of
-     * {@code versionedAddressBook}
+     * Returns an unmodifiable view of the list of not hidden {@code Contact} backed by the internal list of
+     * {@code MyCrm}
      */
     @Override
     public ObservableList<Contact> getFilteredContactList() {

--- a/src/main/java/seedu/mycrm/model/contact/Address.java
+++ b/src/main/java/seedu/mycrm/model/contact/Address.java
@@ -50,7 +50,7 @@ public class Address implements ContactComponent<Address> {
         }
     }
 
-    public static Address getPhone(Optional<String> address) throws ParseException {
+    public static Address getAddress(Optional<String> address) throws ParseException {
         requireNonNull(address);
 
         if (address.orElse("").length() == 0) {

--- a/src/main/java/seedu/mycrm/model/contact/Address.java
+++ b/src/main/java/seedu/mycrm/model/contact/Address.java
@@ -44,7 +44,7 @@ public class Address implements ContactComponent<Address> {
         requireNonNull(address);
 
         if (address.length() == 0) {
-            return EMPTY_ADDRESS;
+            throw new ParseException(MESSAGE_CONSTRAINTS);
         } else {
             return ParserUtil.parseAddress(address);
         }
@@ -54,7 +54,7 @@ public class Address implements ContactComponent<Address> {
         requireNonNull(address);
 
         if (address.orElse("").length() == 0) {
-            return EMPTY_ADDRESS;
+            throw new ParseException(MESSAGE_CONSTRAINTS);
         } else {
             return ParserUtil.parseAddress(address.get());
         }
@@ -67,7 +67,7 @@ public class Address implements ContactComponent<Address> {
 
     @Override
     public boolean isEmpty() {
-        return this == EMPTY_ADDRESS;
+        return value == null;
     }
 
     @Override

--- a/src/main/java/seedu/mycrm/model/contact/Address.java
+++ b/src/main/java/seedu/mycrm/model/contact/Address.java
@@ -3,8 +3,6 @@ package seedu.mycrm.model.contact;
 import static java.util.Objects.requireNonNull;
 import static seedu.mycrm.commons.util.AppUtil.checkArgument;
 
-import java.util.Optional;
-
 import seedu.mycrm.logic.parser.ParserUtil;
 import seedu.mycrm.logic.parser.exceptions.ParseException;
 /**
@@ -50,17 +48,6 @@ public class Address implements ContactComponent<Address> {
         }
     }
 
-    public static Address getAddress(Optional<String> address) throws ParseException {
-        requireNonNull(address);
-
-        if (address.orElse("").length() == 0) {
-            throw new ParseException(MESSAGE_CONSTRAINTS);
-        } else {
-            return ParserUtil.parseAddress(address.get());
-        }
-    }
-
-
     public static Address getEmptyAddress() {
         return EMPTY_ADDRESS;
     }
@@ -89,9 +76,21 @@ public class Address implements ContactComponent<Address> {
 
     @Override
     public boolean equals(Object other) {
-        return other == this // short circuit if same object
-                || (other instanceof Address // instanceof handles nulls
-                && value.equals(((Address) other).value)); // state check
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        if (value == null) {
+            return ((Address) other).value == null;
+        }
+
+        if (other instanceof Address // instanceof handles nulls
+                && value.equals(((Address) other).value)) {
+            return true;
+        }
+
+        return false;
     }
 
     @Override

--- a/src/main/java/seedu/mycrm/model/contact/Email.java
+++ b/src/main/java/seedu/mycrm/model/contact/Email.java
@@ -68,7 +68,7 @@ public class Email implements ContactComponent<Email> {
         requireNonNull(email);
 
         if (email.length() == 0) {
-            return EMPTY_EMAIL;
+            throw new ParseException(MESSAGE_CONSTRAINTS);
         } else {
             return ParserUtil.parseEmail(email);
         }
@@ -78,7 +78,7 @@ public class Email implements ContactComponent<Email> {
         requireNonNull(email);
 
         if (email.orElse("").length() == 0) {
-            return EMPTY_EMAIL;
+            throw new ParseException(MESSAGE_CONSTRAINTS);
         } else {
             return ParserUtil.parseEmail(email.get());
         }
@@ -90,7 +90,7 @@ public class Email implements ContactComponent<Email> {
 
     @Override
     public boolean isEmpty() {
-        return this == EMPTY_EMAIL;
+        return value == null;
     }
 
     @Override

--- a/src/main/java/seedu/mycrm/model/contact/Email.java
+++ b/src/main/java/seedu/mycrm/model/contact/Email.java
@@ -3,8 +3,6 @@ package seedu.mycrm.model.contact;
 import static java.util.Objects.requireNonNull;
 import static seedu.mycrm.commons.util.AppUtil.checkArgument;
 
-import java.util.Optional;
-
 import seedu.mycrm.logic.parser.ParserUtil;
 import seedu.mycrm.logic.parser.exceptions.ParseException;
 /**
@@ -74,16 +72,6 @@ public class Email implements ContactComponent<Email> {
         }
     }
 
-    public static Email getEmail(Optional<String> email) throws ParseException {
-        requireNonNull(email);
-
-        if (email.orElse("").length() == 0) {
-            throw new ParseException(MESSAGE_CONSTRAINTS);
-        } else {
-            return ParserUtil.parseEmail(email.get());
-        }
-    }
-
     public static Email getEmptyEmail() {
         return EMPTY_EMAIL;
     }
@@ -105,9 +93,21 @@ public class Email implements ContactComponent<Email> {
 
     @Override
     public boolean equals(Object other) {
-        return other == this // short circuit if same object
-                || (other instanceof Email // instanceof handles nulls
-                && value.equals(((Email) other).value)); // state check
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        if (value == null) {
+            return ((Email) other).value == null;
+        }
+
+        if (other instanceof Email // instanceof handles nulls
+                && value.equals(((Email) other).value)) {
+            return true;
+        }
+
+        return false;
     }
 
     @Override

--- a/src/main/java/seedu/mycrm/model/contact/Name.java
+++ b/src/main/java/seedu/mycrm/model/contact/Name.java
@@ -3,8 +3,6 @@ package seedu.mycrm.model.contact;
 import static java.util.Objects.requireNonNull;
 import static seedu.mycrm.commons.util.AppUtil.checkArgument;
 
-import java.util.Optional;
-
 import seedu.mycrm.logic.parser.ParserUtil;
 import seedu.mycrm.logic.parser.exceptions.ParseException;
 /**
@@ -49,14 +47,6 @@ public class Name implements ContactComponent<Name> {
         return ParserUtil.parseName(name);
     }
 
-    public static Name getName(Optional<String> name) throws ParseException {
-        requireNonNull(name);
-        assert name.orElse("").length() > 0;
-
-        String nameString = name.get();
-        return ParserUtil.parseName(nameString);
-    }
-
     /**
      * Returns true if a given string is a valid name.
      */
@@ -82,9 +72,21 @@ public class Name implements ContactComponent<Name> {
 
     @Override
     public boolean equals(Object other) {
-        return other == this // short circuit if same object
-                || (other instanceof Name // instanceof handles nulls
-                && fullName.equals(((Name) other).fullName)); // state check
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        if (fullName == null) {
+            return ((Name) other).fullName == null;
+        }
+
+        if (other instanceof Name // instanceof handles nulls
+                && fullName.equals(((Name) other).fullName)) {
+            return true;
+        }
+
+        return false;
     }
 
     @Override

--- a/src/main/java/seedu/mycrm/model/contact/Name.java
+++ b/src/main/java/seedu/mycrm/model/contact/Name.java
@@ -66,7 +66,7 @@ public class Name implements ContactComponent<Name> {
 
     @Override
     public boolean isEmpty() {
-        return this == EMPTY_NAME;
+        return fullName == null;
     }
 
     @Override

--- a/src/main/java/seedu/mycrm/model/contact/Phone.java
+++ b/src/main/java/seedu/mycrm/model/contact/Phone.java
@@ -3,8 +3,6 @@ package seedu.mycrm.model.contact;
 import static java.util.Objects.requireNonNull;
 import static seedu.mycrm.commons.util.AppUtil.checkArgument;
 
-import java.util.Optional;
-
 import seedu.mycrm.logic.parser.ParserUtil;
 import seedu.mycrm.logic.parser.exceptions.ParseException;
 /**
@@ -47,16 +45,6 @@ public class Phone implements ContactComponent<Phone> {
         }
     }
 
-    public static Phone getPhone(Optional<String> phone) throws ParseException {
-        requireNonNull(phone);
-
-        if (phone.orElse("").length() == 0) {
-            throw new ParseException(MESSAGE_CONSTRAINTS);
-        } else {
-            return ParserUtil.parsePhone(phone.get());
-        }
-    }
-
     /**
      * Returns true if a given string is a valid phone number.
      */
@@ -85,9 +73,21 @@ public class Phone implements ContactComponent<Phone> {
 
     @Override
     public boolean equals(Object other) {
-        return other == this // short circuit if same object
-                || (other instanceof Phone // instanceof handles nulls
-                && value.equals(((Phone) other).value)); // state check
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        if (value == null) {
+            return ((Phone) other).value == null;
+        }
+
+        if (other instanceof Phone // instanceof handles nulls
+                && value.equals(((Phone) other).value)) {
+            return true;
+        }
+
+        return false;
     }
 
     @Override

--- a/src/main/java/seedu/mycrm/model/contact/Phone.java
+++ b/src/main/java/seedu/mycrm/model/contact/Phone.java
@@ -41,7 +41,7 @@ public class Phone implements ContactComponent<Phone> {
         requireNonNull(phone);
 
         if (phone.length() == 0) {
-            return EMPTY_PHONE;
+            throw new ParseException(MESSAGE_CONSTRAINTS);
         } else {
             return ParserUtil.parsePhone(phone);
         }
@@ -51,7 +51,7 @@ public class Phone implements ContactComponent<Phone> {
         requireNonNull(phone);
 
         if (phone.orElse("").length() == 0) {
-            return EMPTY_PHONE;
+            throw new ParseException(MESSAGE_CONSTRAINTS);
         } else {
             return ParserUtil.parsePhone(phone.get());
         }
@@ -70,7 +70,7 @@ public class Phone implements ContactComponent<Phone> {
 
     @Override
     public boolean isEmpty() {
-        return this == EMPTY_PHONE;
+        return value == null;
     }
 
     @Override

--- a/src/main/java/seedu/mycrm/storage/JsonAdaptedContact.java
+++ b/src/main/java/seedu/mycrm/storage/JsonAdaptedContact.java
@@ -80,13 +80,13 @@ class JsonAdaptedContact {
         if (!Name.isValidName(name)) {
             throw new IllegalValueException(Name.MESSAGE_CONSTRAINTS);
         }
-        final Name modelName = new Name(name);
-
+        final Name modelName = Name.getName(name);
 
         if (phone != null && !Phone.isValidPhone(phone)) {
             throw new IllegalValueException(Phone.MESSAGE_CONSTRAINTS);
         }
         final Phone modelPhone;
+
         if (phone != null) {
             modelPhone = new Phone(phone);
         } else {

--- a/src/main/java/seedu/mycrm/ui/contact/ContactCard.java
+++ b/src/main/java/seedu/mycrm/ui/contact/ContactCard.java
@@ -56,9 +56,9 @@ public class ContactCard extends UiPart<Region> {
     private void setContactInfo(Contact contact, int displayedIndex) {
         id.setText(displayedIndex + ". ");
         name.setText(contact.getName().fullName);
-        phone.setText(contact.getPhone().value);
-        address.setText(contact.getAddress().value);
-        email.setText(contact.getEmail().value);
+        phone.setText("Phone: " + contact.getPhone().toString());
+        address.setText("Address: " + contact.getAddress().toString());
+        email.setText("Email: " + contact.getEmail().toString());
 
         if (contact.checkIsHidden()) {
             addHiddenTag();

--- a/src/main/java/seedu/mycrm/ui/contact/ContactCard.java
+++ b/src/main/java/seedu/mycrm/ui/contact/ContactCard.java
@@ -55,7 +55,7 @@ public class ContactCard extends UiPart<Region> {
 
     private void setContactInfo(Contact contact, int displayedIndex) {
         id.setText(displayedIndex + ". ");
-        name.setText(contact.getName().fullName);
+        name.setText(contact.getName().toString());
         phone.setText("Phone: " + contact.getPhone().toString());
         address.setText("Address: " + contact.getAddress().toString());
         email.setText("Email: " + contact.getEmail().toString());

--- a/src/main/java/seedu/mycrm/ui/contact/ContactCard.java
+++ b/src/main/java/seedu/mycrm/ui/contact/ContactCard.java
@@ -61,7 +61,7 @@ public class ContactCard extends UiPart<Region> {
         email.setText(contact.getEmail().value);
 
         if (contact.checkIsHidden()) {
-            addContactTag();
+            addHiddenTag();
         }
 
         contact.getTags().stream()
@@ -69,7 +69,7 @@ public class ContactCard extends UiPart<Region> {
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
     }
 
-    private void addContactTag() {
+    private void addHiddenTag() {
         isHidden.getChildren().add(new Label("Hidden"));
     }
 

--- a/src/test/java/seedu/mycrm/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/mycrm/logic/commands/CommandTestUtil.java
@@ -62,8 +62,8 @@ public class CommandTestUtil {
     public static final String VALID_EMAIL_BOB = "bob@example.com";
     public static final String VALID_ADDRESS_AMY = "Block 312, Amy Street 1";
     public static final String VALID_ADDRESS_BOB = "Block 123, Bobby Street 3";
-    public static final String VALID_TAG_HUSBAND = "husband";
-    public static final String VALID_TAG_FRIEND = "friend";
+    public static final String VALID_TAG_FIRST_TIER = "1st tier";
+    public static final String VALID_TAG_SECOND_TIER = "2nd tier";
 
     public static final String NAME_DESC_AMY = " " + PREFIX_NAME + VALID_NAME_AMY;
     public static final String NAME_DESC_BOB = " " + PREFIX_NAME + VALID_NAME_BOB;
@@ -73,14 +73,14 @@ public class CommandTestUtil {
     public static final String EMAIL_DESC_BOB = " " + PREFIX_EMAIL + VALID_EMAIL_BOB;
     public static final String ADDRESS_DESC_AMY = " " + PREFIX_ADDRESS + VALID_ADDRESS_AMY;
     public static final String ADDRESS_DESC_BOB = " " + PREFIX_ADDRESS + VALID_ADDRESS_BOB;
-    public static final String TAG_DESC_FRIEND = " " + PREFIX_TAG + VALID_TAG_FRIEND;
-    public static final String TAG_DESC_HUSBAND = " " + PREFIX_TAG + VALID_TAG_HUSBAND;
+    public static final String TAG_DESC_SECOND_TIER = " " + PREFIX_TAG + VALID_TAG_SECOND_TIER;
+    public static final String TAG_DESC_FIRST_TIER = " " + PREFIX_TAG + VALID_TAG_FIRST_TIER;
 
     public static final String INVALID_NAME_DESC = " " + PREFIX_NAME + "James&"; // '&' not allowed in names
     public static final String INVALID_PHONE_DESC = " " + PREFIX_PHONE + "911a"; // 'a' not allowed in phones
     public static final String INVALID_EMAIL_DESC = " " + PREFIX_EMAIL + "bob!yahoo"; // missing '@' symbol
     public static final String INVALID_ADDRESS_DESC = " " + PREFIX_ADDRESS; // empty string not allowed for addresses
-    public static final String INVALID_TAG_DESC = " " + PREFIX_TAG + "hubby*"; // '*' not allowed in tags
+    public static final String INVALID_TAG_DESC = " " + PREFIX_TAG + "cooperation friend*"; // '*' not allowed in tags
 
     public static final String PREAMBLE_WHITESPACE = "\t  \r  \n";
     public static final String PREAMBLE_NON_EMPTY = "NonEmptyPreamble";
@@ -133,10 +133,10 @@ public class CommandTestUtil {
     static {
         DESC_AMY = new EditContactDescriptorBuilder().withName(VALID_NAME_AMY)
                 .withPhone(VALID_PHONE_AMY).withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY)
-                .withTags(VALID_TAG_FRIEND).build();
+                .withTags(VALID_TAG_SECOND_TIER).build();
         DESC_BOB = new EditContactDescriptorBuilder().withName(VALID_NAME_BOB)
                 .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB)
-                .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).build();
+                .withTags(VALID_TAG_FIRST_TIER, VALID_TAG_SECOND_TIER).build();
         DESC_DONE = new EditTemplateDescriptorBuilder().withSubject(VALID_SUBJECT_DONE)
                 .withBody(VALID_BODY_DONE).build();
         DESC_COMPLETE = new EditTemplateDescriptorBuilder().withSubject(VALID_SUBJECT_COMPLETE)

--- a/src/test/java/seedu/mycrm/logic/commands/contacts/DeleteContactCommandTest.java
+++ b/src/test/java/seedu/mycrm/logic/commands/contacts/DeleteContactCommandTest.java
@@ -5,8 +5,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.mycrm.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.mycrm.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.mycrm.logic.commands.CommandTestUtil.showContactAtIndex;
-import static seedu.mycrm.testutil.TypicalContacts.getTypicalMyCrm;
 import static seedu.mycrm.testutil.TypicalContacts.getOneTypicalMyCrm;
+import static seedu.mycrm.testutil.TypicalContacts.getTypicalMyCrm;
 import static seedu.mycrm.testutil.TypicalIndexes.INDEX_FIRST_CONTACT;
 import static seedu.mycrm.testutil.TypicalIndexes.INDEX_SECOND_CONTACT;
 
@@ -51,7 +51,8 @@ public class DeleteContactCommandTest {
 
     @Test
     public void execute_validIndexFilteredList_success() {
-        Contact contactToDelete = modelOneTypicalContact.getFilteredContactList().get(INDEX_FIRST_CONTACT.getZeroBased());
+        Contact contactToDelete = modelOneTypicalContact.getFilteredContactList()
+                .get(INDEX_FIRST_CONTACT.getZeroBased());
         DeleteContactCommand deleteCommand = new DeleteContactCommand(INDEX_FIRST_CONTACT);
 
         String expectedMessage = String.format(DeleteContactCommand.MESSAGE_DELETE_CONTACT_SUCCESS, contactToDelete);

--- a/src/test/java/seedu/mycrm/logic/commands/contacts/DeleteContactCommandTest.java
+++ b/src/test/java/seedu/mycrm/logic/commands/contacts/DeleteContactCommandTest.java
@@ -6,6 +6,7 @@ import static seedu.mycrm.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.mycrm.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.mycrm.logic.commands.CommandTestUtil.showContactAtIndex;
 import static seedu.mycrm.testutil.TypicalContacts.getTypicalMyCrm;
+import static seedu.mycrm.testutil.TypicalContacts.getOneTypicalMyCrm;
 import static seedu.mycrm.testutil.TypicalIndexes.INDEX_FIRST_CONTACT;
 import static seedu.mycrm.testutil.TypicalIndexes.INDEX_SECOND_CONTACT;
 
@@ -24,40 +25,56 @@ import seedu.mycrm.model.contact.Contact;
  */
 public class DeleteContactCommandTest {
 
-    private Model model = new ModelManager(getTypicalMyCrm(), new UserPrefs());
+    private Model modelTypicalContact = new ModelManager(getTypicalMyCrm(), new UserPrefs());
+    private Model modelOneTypicalContact = new ModelManager(getOneTypicalMyCrm(), new UserPrefs());
 
     @Test
     public void execute_validIndexUnfilteredList_success() {
-        Contact contactToDelete = model.getFilteredContactList().get(INDEX_FIRST_CONTACT.getZeroBased());
+        Contact contactToDelete = modelTypicalContact.getFilteredContactList().get(INDEX_FIRST_CONTACT.getZeroBased());
         DeleteContactCommand deleteCommand = new DeleteContactCommand(INDEX_FIRST_CONTACT);
 
         String expectedMessage = String.format(DeleteContactCommand.MESSAGE_DELETE_CONTACT_SUCCESS, contactToDelete);
 
-        ModelManager expectedModel = new ModelManager(model.getMyCrm(), new UserPrefs());
+        ModelManager expectedModel = new ModelManager(modelTypicalContact.getMyCrm(), new UserPrefs());
         expectedModel.deleteContact(contactToDelete);
 
-        assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
+        assertCommandSuccess(deleteCommand, modelTypicalContact, expectedMessage, expectedModel);
     }
 
     @Test
     public void execute_invalidIndexUnfilteredList_throwsCommandException() {
-        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredContactList().size() + 1);
+        Index outOfBoundIndex = Index.fromOneBased(modelTypicalContact.getFilteredContactList().size() + 1);
         DeleteContactCommand deleteCommand = new DeleteContactCommand(outOfBoundIndex);
 
-        assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_CONTACT_DISPLAYED_INDEX);
+        assertCommandFailure(deleteCommand, modelTypicalContact, Messages.MESSAGE_INVALID_CONTACT_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_validIndexFilteredList_success() {
+        Contact contactToDelete = modelOneTypicalContact.getFilteredContactList().get(INDEX_FIRST_CONTACT.getZeroBased());
+        DeleteContactCommand deleteCommand = new DeleteContactCommand(INDEX_FIRST_CONTACT);
+
+        String expectedMessage = String.format(DeleteContactCommand.MESSAGE_DELETE_CONTACT_SUCCESS, contactToDelete);
+
+        ModelManager expectedModel = new ModelManager(modelOneTypicalContact.getMyCrm(), new UserPrefs());
+        expectedModel.deleteContact(contactToDelete);
+
+        showNoContact(expectedModel);
+
+        assertCommandSuccess(deleteCommand, modelOneTypicalContact, expectedMessage, expectedModel);
     }
 
     @Test
     public void execute_invalidIndexFilteredList_throwsCommandException() {
-        showContactAtIndex(model, INDEX_FIRST_CONTACT);
+        showContactAtIndex(modelOneTypicalContact, INDEX_FIRST_CONTACT);
 
         Index outOfBoundIndex = INDEX_SECOND_CONTACT;
         // ensures that outOfBoundIndex is still in bounds of myCrm list
-        assertTrue(outOfBoundIndex.getZeroBased() < model.getMyCrm().getContactList().size());
+        assertTrue(outOfBoundIndex.getZeroBased() < modelTypicalContact.getMyCrm().getContactList().size());
 
         DeleteContactCommand deleteCommand = new DeleteContactCommand(outOfBoundIndex);
 
-        assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_CONTACT_DISPLAYED_INDEX);
+        assertCommandFailure(deleteCommand, modelOneTypicalContact, Messages.MESSAGE_INVALID_CONTACT_DISPLAYED_INDEX);
     }
 
     @Test

--- a/src/test/java/seedu/mycrm/logic/commands/contacts/EditContactCommandTest.java
+++ b/src/test/java/seedu/mycrm/logic/commands/contacts/EditContactCommandTest.java
@@ -6,7 +6,7 @@ import static seedu.mycrm.logic.commands.CommandTestUtil.DESC_AMY;
 import static seedu.mycrm.logic.commands.CommandTestUtil.DESC_BOB;
 import static seedu.mycrm.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.mycrm.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
-import static seedu.mycrm.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
+import static seedu.mycrm.logic.commands.CommandTestUtil.VALID_TAG_FIRST_TIER;
 import static seedu.mycrm.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.mycrm.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.mycrm.logic.commands.CommandTestUtil.showContactAtIndex;
@@ -52,10 +52,10 @@ class EditContactCommandTest {
 
         ContactBuilder contactInList = new ContactBuilder(lastContact);
         Contact editedContact = contactInList.withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
-                .withTags(VALID_TAG_HUSBAND).build();
+                .withTags(VALID_TAG_FIRST_TIER).build();
 
         EditContactCommand.EditContactDescriptor descriptor = new EditContactDescriptorBuilder()
-                .withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB).withTags(VALID_TAG_HUSBAND).build();
+                .withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB).withTags(VALID_TAG_FIRST_TIER).build();
         EditContactCommand editCommand = new EditContactCommand(indexLastContact, descriptor);
 
         String expectedMessage = String.format(EditContactCommand.MESSAGE_EDIT_CONTACT_SUCCESS, editedContact);

--- a/src/test/java/seedu/mycrm/logic/commands/contacts/EditContactDescriptorTest.java
+++ b/src/test/java/seedu/mycrm/logic/commands/contacts/EditContactDescriptorTest.java
@@ -8,7 +8,7 @@ import static seedu.mycrm.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
 import static seedu.mycrm.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
 import static seedu.mycrm.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.mycrm.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
-import static seedu.mycrm.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
+import static seedu.mycrm.logic.commands.CommandTestUtil.VALID_TAG_FIRST_TIER;
 
 import org.junit.jupiter.api.Test;
 
@@ -52,7 +52,7 @@ public class EditContactDescriptorTest {
         assertFalse(DESC_AMY.equals(editedAmy));
 
         // different tags -> returns false
-        editedAmy = new EditContactDescriptorBuilder(DESC_AMY).withTags(VALID_TAG_HUSBAND).build();
+        editedAmy = new EditContactDescriptorBuilder(DESC_AMY).withTags(VALID_TAG_FIRST_TIER).build();
         assertFalse(DESC_AMY.equals(editedAmy));
     }
 }

--- a/src/test/java/seedu/mycrm/logic/parser/CommandParserTestUtil.java
+++ b/src/test/java/seedu/mycrm/logic/parser/CommandParserTestUtil.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import seedu.mycrm.logic.commands.Command;
 import seedu.mycrm.logic.parser.exceptions.ParseException;
-
 /**
  * Contains helper methods for testing command parsers.
  */

--- a/src/test/java/seedu/mycrm/logic/parser/contacts/AddContactCommandParserTest.java
+++ b/src/test/java/seedu/mycrm/logic/parser/contacts/AddContactCommandParserTest.java
@@ -16,14 +16,14 @@ import static seedu.mycrm.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
 import static seedu.mycrm.logic.commands.CommandTestUtil.PHONE_DESC_BOB;
 import static seedu.mycrm.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
 import static seedu.mycrm.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
-import static seedu.mycrm.logic.commands.CommandTestUtil.TAG_DESC_FRIEND;
-import static seedu.mycrm.logic.commands.CommandTestUtil.TAG_DESC_HUSBAND;
+import static seedu.mycrm.logic.commands.CommandTestUtil.TAG_DESC_FIRST_TIER;
+import static seedu.mycrm.logic.commands.CommandTestUtil.TAG_DESC_SECOND_TIER;
 import static seedu.mycrm.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
 import static seedu.mycrm.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
 import static seedu.mycrm.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.mycrm.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
-import static seedu.mycrm.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
-import static seedu.mycrm.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
+import static seedu.mycrm.logic.commands.CommandTestUtil.VALID_TAG_FIRST_TIER;
+import static seedu.mycrm.logic.commands.CommandTestUtil.VALID_TAG_SECOND_TIER;
 import static seedu.mycrm.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.mycrm.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.mycrm.testutil.TypicalContacts.AMY;
@@ -44,41 +44,74 @@ class AddContactCommandParserTest {
 
     @Test
     public void parse_allFieldsPresent_success() {
-        Contact expectedContact = new ContactBuilder(BOB).withTags(VALID_TAG_FRIEND).build();
+        Contact expectedContact = new ContactBuilder(BOB).withTags(VALID_TAG_SECOND_TIER).build();
 
         // whitespace only preamble
         assertParseSuccess(parser, PREAMBLE_WHITESPACE + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                + ADDRESS_DESC_BOB + TAG_DESC_FRIEND, new AddContactCommand(expectedContact));
+                + ADDRESS_DESC_BOB + TAG_DESC_SECOND_TIER, new AddContactCommand(expectedContact));
 
         // multiple names - last name accepted
         assertParseSuccess(parser, NAME_DESC_AMY + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                + ADDRESS_DESC_BOB + TAG_DESC_FRIEND, new AddContactCommand(expectedContact));
+                + ADDRESS_DESC_BOB + TAG_DESC_SECOND_TIER, new AddContactCommand(expectedContact));
 
         // multiple phones - last phone accepted
         assertParseSuccess(parser, NAME_DESC_BOB + PHONE_DESC_AMY + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                + ADDRESS_DESC_BOB + TAG_DESC_FRIEND, new AddContactCommand(expectedContact));
+                + ADDRESS_DESC_BOB + TAG_DESC_SECOND_TIER, new AddContactCommand(expectedContact));
 
         // multiple emails - last email accepted
         assertParseSuccess(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_AMY + EMAIL_DESC_BOB
-                + ADDRESS_DESC_BOB + TAG_DESC_FRIEND, new AddContactCommand(expectedContact));
+                + ADDRESS_DESC_BOB + TAG_DESC_SECOND_TIER, new AddContactCommand(expectedContact));
 
         // multiple addresses - last address accepted
         assertParseSuccess(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_AMY
-                + ADDRESS_DESC_BOB + TAG_DESC_FRIEND, new AddContactCommand(expectedContact));
+                + ADDRESS_DESC_BOB + TAG_DESC_SECOND_TIER, new AddContactCommand(expectedContact));
 
         // multiple tags - all accepted
-        Contact expectedContactMultipleTags = new ContactBuilder(BOB).withTags(VALID_TAG_FRIEND, VALID_TAG_HUSBAND)
-                .build();
+        Contact expectedContactMultipleTags = new ContactBuilder(BOB).withTags(VALID_TAG_SECOND_TIER,
+                VALID_TAG_FIRST_TIER).build();
         assertParseSuccess(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
-                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, new AddContactCommand(expectedContactMultipleTags));
+                + TAG_DESC_FIRST_TIER + TAG_DESC_SECOND_TIER, new AddContactCommand(expectedContactMultipleTags));
     }
 
     @Test
     public void parse_optionalFieldsMissing_success() {
         // zero tags
-        Contact expectedContact = new ContactBuilder(AMY).withTags().build();
+        Contact expectedContactWithoutTags = new ContactBuilder(AMY).withTags().build();
         assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY,
-                new AddContactCommand(expectedContact));
+                new AddContactCommand(expectedContactWithoutTags));
+
+        // no address
+        Contact expectedContactWithoutAddress = new ContactBuilder(AMY).withAddress(null).build();
+        assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + TAG_DESC_SECOND_TIER,
+                new AddContactCommand(expectedContactWithoutAddress));
+
+        // no email
+        Contact expectedContactWithoutEmail = new ContactBuilder(AMY).withEmail(null).build();
+        assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + ADDRESS_DESC_AMY + TAG_DESC_SECOND_TIER,
+                new AddContactCommand(expectedContactWithoutEmail));
+
+        // no phone
+        Contact expectedContactWithoutPhone = new ContactBuilder(AMY).withPhone(null).build();
+        assertParseSuccess(parser, NAME_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY + TAG_DESC_SECOND_TIER,
+                new AddContactCommand(expectedContactWithoutPhone));
+
+        // only address
+        Contact expectedContactWithOnlyAddress = new ContactBuilder(AMY).withPhone(null)
+                .withEmail(null).withTags().build();
+        assertParseSuccess(parser, NAME_DESC_AMY + ADDRESS_DESC_AMY,
+                new AddContactCommand(expectedContactWithOnlyAddress));
+
+        // only email
+        Contact expectedContactWithOnlyEmail = new ContactBuilder(AMY).withPhone(null)
+                .withAddress(null).withTags().build();
+        assertParseSuccess(parser, NAME_DESC_AMY + EMAIL_DESC_AMY,
+                new AddContactCommand(expectedContactWithOnlyEmail));
+
+        // only Phone
+        Contact expectedContactWithOnlyPhone = new ContactBuilder(AMY).withEmail(null)
+                .withAddress(null).withTags().build();
+        assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY,
+                new AddContactCommand(expectedContactWithOnlyPhone));
     }
 
     @Test
@@ -92,25 +125,35 @@ class AddContactCommandParserTest {
         // all prefixes missing
         assertParseFailure(parser, VALID_NAME_BOB + VALID_PHONE_BOB + VALID_EMAIL_BOB + VALID_ADDRESS_BOB,
                 expectedMessage);
+
+        String expectedMessageMissingComponent = String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                AddContactCommand.MESSAGE_AT_LEAST_ONE_COMPONENT);
+        // missing at least one field of phone, email, or address
+        assertParseFailure(parser, NAME_DESC_BOB,
+                expectedMessageMissingComponent);
     }
 
     @Test
     public void parse_invalidValue_failure() {
         // invalid name
         assertParseFailure(parser, INVALID_NAME_DESC + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
-                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Name.MESSAGE_CONSTRAINTS);
+                + TAG_DESC_FIRST_TIER + TAG_DESC_SECOND_TIER, Name.MESSAGE_CONSTRAINTS);
 
         // invalid phone
         assertParseFailure(parser, NAME_DESC_BOB + INVALID_PHONE_DESC + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
-                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Phone.MESSAGE_CONSTRAINTS);
+                + TAG_DESC_FIRST_TIER + TAG_DESC_SECOND_TIER, Phone.MESSAGE_CONSTRAINTS);
+
+        // invalid address
+        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + INVALID_EMAIL_DESC + INVALID_ADDRESS_DESC
+                + TAG_DESC_FIRST_TIER + TAG_DESC_SECOND_TIER, Email.MESSAGE_CONSTRAINTS);
 
         // invalid email
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + INVALID_EMAIL_DESC + ADDRESS_DESC_BOB
-                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Email.MESSAGE_CONSTRAINTS);
+                + TAG_DESC_FIRST_TIER + TAG_DESC_SECOND_TIER, Email.MESSAGE_CONSTRAINTS);
 
         // invalid tag
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
-                + INVALID_TAG_DESC + VALID_TAG_FRIEND, Tag.MESSAGE_CONSTRAINTS);
+                + INVALID_TAG_DESC + VALID_TAG_SECOND_TIER, Tag.MESSAGE_CONSTRAINTS);
 
         // two invalid values, only first invalid value reported
         assertParseFailure(parser, INVALID_NAME_DESC + PHONE_DESC_BOB + EMAIL_DESC_BOB + INVALID_ADDRESS_DESC,
@@ -118,7 +161,7 @@ class AddContactCommandParserTest {
 
         // non-empty preamble
         assertParseFailure(parser, PREAMBLE_NON_EMPTY + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                        + ADDRESS_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
+                        + ADDRESS_DESC_BOB + TAG_DESC_FIRST_TIER + TAG_DESC_SECOND_TIER,
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddContactCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/seedu/mycrm/logic/parser/contacts/EditContactCommandParserTest.java
+++ b/src/test/java/seedu/mycrm/logic/parser/contacts/EditContactCommandParserTest.java
@@ -13,8 +13,8 @@ import static seedu.mycrm.logic.commands.CommandTestUtil.INVALID_TAG_DESC;
 import static seedu.mycrm.logic.commands.CommandTestUtil.NAME_DESC_AMY;
 import static seedu.mycrm.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
 import static seedu.mycrm.logic.commands.CommandTestUtil.PHONE_DESC_BOB;
-import static seedu.mycrm.logic.commands.CommandTestUtil.TAG_DESC_FRIEND;
-import static seedu.mycrm.logic.commands.CommandTestUtil.TAG_DESC_HUSBAND;
+import static seedu.mycrm.logic.commands.CommandTestUtil.TAG_DESC_FIRST_TIER;
+import static seedu.mycrm.logic.commands.CommandTestUtil.TAG_DESC_SECOND_TIER;
 import static seedu.mycrm.logic.commands.CommandTestUtil.VALID_ADDRESS_AMY;
 import static seedu.mycrm.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
 import static seedu.mycrm.logic.commands.CommandTestUtil.VALID_EMAIL_AMY;
@@ -22,8 +22,8 @@ import static seedu.mycrm.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
 import static seedu.mycrm.logic.commands.CommandTestUtil.VALID_NAME_AMY;
 import static seedu.mycrm.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
 import static seedu.mycrm.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
-import static seedu.mycrm.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
-import static seedu.mycrm.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
+import static seedu.mycrm.logic.commands.CommandTestUtil.VALID_TAG_FIRST_TIER;
+import static seedu.mycrm.logic.commands.CommandTestUtil.VALID_TAG_SECOND_TIER;
 import static seedu.mycrm.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.mycrm.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.mycrm.logic.parser.CommandParserTestUtil.assertParseSuccess;
@@ -96,9 +96,12 @@ public class EditContactCommandParserTest {
 
         // while parsing {@code PREFIX_TAG} alone will reset the tags of the {@code Contact} being edited,
         // parsing it together with a valid tag results in error
-        assertParseFailure(parser, "1" + TAG_DESC_FRIEND + TAG_DESC_HUSBAND + TAG_EMPTY, Tag.MESSAGE_CONSTRAINTS);
-        assertParseFailure(parser, "1" + TAG_DESC_FRIEND + TAG_EMPTY + TAG_DESC_HUSBAND, Tag.MESSAGE_CONSTRAINTS);
-        assertParseFailure(parser, "1" + TAG_EMPTY + TAG_DESC_FRIEND + TAG_DESC_HUSBAND, Tag.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, "1" + TAG_DESC_SECOND_TIER + TAG_DESC_FIRST_TIER + TAG_EMPTY,
+                Tag.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, "1" + TAG_DESC_SECOND_TIER + TAG_EMPTY + TAG_DESC_FIRST_TIER,
+                Tag.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, "1" + TAG_EMPTY + TAG_DESC_SECOND_TIER + TAG_DESC_FIRST_TIER,
+                Tag.MESSAGE_CONSTRAINTS);
 
         // multiple invalid values, but only the first invalid value is captured
         assertParseFailure(parser, "1" + INVALID_NAME_DESC + INVALID_EMAIL_DESC + VALID_ADDRESS_AMY + VALID_PHONE_AMY,
@@ -108,12 +111,12 @@ public class EditContactCommandParserTest {
     @Test
     public void parse_allFieldsSpecified_success() {
         Index targetIndex = INDEX_SECOND_CONTACT;
-        String userInput = targetIndex.getOneBased() + PHONE_DESC_BOB + TAG_DESC_HUSBAND
-                + EMAIL_DESC_AMY + ADDRESS_DESC_AMY + NAME_DESC_AMY + TAG_DESC_FRIEND;
+        String userInput = targetIndex.getOneBased() + PHONE_DESC_BOB + TAG_DESC_FIRST_TIER
+                + EMAIL_DESC_AMY + ADDRESS_DESC_AMY + NAME_DESC_AMY + TAG_DESC_SECOND_TIER;
 
         EditContactDescriptor descriptor = new EditContactDescriptorBuilder().withName(VALID_NAME_AMY)
                 .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY)
-                .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).build();
+                .withTags(VALID_TAG_FIRST_TIER, VALID_TAG_SECOND_TIER).build();
         EditContactCommand expectedCommand = new EditContactCommand(targetIndex, descriptor);
 
         assertParseSuccess(parser, userInput, expectedCommand);
@@ -159,8 +162,8 @@ public class EditContactCommandParserTest {
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // tags
-        userInput = targetIndex.getOneBased() + TAG_DESC_FRIEND;
-        descriptor = new EditContactDescriptorBuilder().withTags(VALID_TAG_FRIEND).build();
+        userInput = targetIndex.getOneBased() + TAG_DESC_SECOND_TIER;
+        descriptor = new EditContactDescriptorBuilder().withTags(VALID_TAG_SECOND_TIER).build();
         expectedCommand = new EditContactCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
     }
@@ -169,12 +172,12 @@ public class EditContactCommandParserTest {
     public void parse_multipleRepeatedFields_acceptsLast() {
         Index targetIndex = INDEX_FIRST_CONTACT;
         String userInput = targetIndex.getOneBased() + PHONE_DESC_AMY + ADDRESS_DESC_AMY + EMAIL_DESC_AMY
-                + TAG_DESC_FRIEND + PHONE_DESC_AMY + ADDRESS_DESC_AMY + EMAIL_DESC_AMY + TAG_DESC_FRIEND
-                + PHONE_DESC_BOB + ADDRESS_DESC_BOB + EMAIL_DESC_BOB + TAG_DESC_HUSBAND;
+                + TAG_DESC_SECOND_TIER + PHONE_DESC_AMY + ADDRESS_DESC_AMY + EMAIL_DESC_AMY + TAG_DESC_SECOND_TIER
+                + PHONE_DESC_BOB + ADDRESS_DESC_BOB + EMAIL_DESC_BOB + TAG_DESC_FIRST_TIER;
 
         EditContactDescriptor descriptor = new EditContactDescriptorBuilder().withPhone(VALID_PHONE_BOB)
-                .withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_FRIEND, VALID_TAG_HUSBAND)
-                .build();
+                .withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_SECOND_TIER,
+                        VALID_TAG_FIRST_TIER).build();
         EditContactCommand expectedCommand = new EditContactCommand(targetIndex, descriptor);
 
         assertParseSuccess(parser, userInput, expectedCommand);

--- a/src/test/java/seedu/mycrm/logic/parser/contacts/HideContactCommandParserTest.java
+++ b/src/test/java/seedu/mycrm/logic/parser/contacts/HideContactCommandParserTest.java
@@ -19,8 +19,20 @@ public class HideContactCommandParserTest {
     }
 
     @Test
+    public void parse_NullArgs_throwsParseException() {
+        assertParseFailure(parser, "", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                HideContactCommand.MESSAGE_USAGE));
+    }
+
+    @Test
     public void parse_invalidArgs_throwsParseException() {
         assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                HideContactCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_invalidIndex_throwsParseException() {
+        assertParseFailure(parser, "-100", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                 HideContactCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/seedu/mycrm/logic/parser/contacts/HideContactCommandParserTest.java
+++ b/src/test/java/seedu/mycrm/logic/parser/contacts/HideContactCommandParserTest.java
@@ -19,7 +19,7 @@ public class HideContactCommandParserTest {
     }
 
     @Test
-    public void parse_NullArgs_throwsParseException() {
+    public void parse_nullArgs_throwsParseException() {
         assertParseFailure(parser, "", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                 HideContactCommand.MESSAGE_USAGE));
     }

--- a/src/test/java/seedu/mycrm/model/MyCrmTest.java
+++ b/src/test/java/seedu/mycrm/model/MyCrmTest.java
@@ -4,7 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.mycrm.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
-import static seedu.mycrm.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
+import static seedu.mycrm.logic.commands.CommandTestUtil.VALID_TAG_FIRST_TIER;
 import static seedu.mycrm.testutil.Assert.assertThrows;
 import static seedu.mycrm.testutil.TypicalContacts.ALICE;
 import static seedu.mycrm.testutil.TypicalContacts.getTypicalMyCrm;
@@ -53,7 +53,7 @@ public class MyCrmTest {
     @Test
     public void resetData_withDuplicateContacts_throwsDuplicateContactException() {
         // Two contacts with the same identity fields
-        Contact editedAlice = new ContactBuilder(ALICE).withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_HUSBAND)
+        Contact editedAlice = new ContactBuilder(ALICE).withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_FIRST_TIER)
                 .build();
         List<Contact> newContacts = Arrays.asList(ALICE, editedAlice);
         MyCrmStub newData = new MyCrmStub(newContacts);
@@ -80,7 +80,7 @@ public class MyCrmTest {
     @Test
     public void hasContact_contactWithSameIdentityFieldsInMyCrm_returnsTrue() {
         myCrm.addContact(ALICE);
-        Contact editedAlice = new ContactBuilder(ALICE).withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_HUSBAND)
+        Contact editedAlice = new ContactBuilder(ALICE).withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_FIRST_TIER)
                 .build();
         assertTrue(myCrm.hasContact(editedAlice));
     }

--- a/src/test/java/seedu/mycrm/model/contact/ContactTest.java
+++ b/src/test/java/seedu/mycrm/model/contact/ContactTest.java
@@ -6,7 +6,7 @@ import static seedu.mycrm.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
 import static seedu.mycrm.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
 import static seedu.mycrm.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.mycrm.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
-import static seedu.mycrm.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
+import static seedu.mycrm.logic.commands.CommandTestUtil.VALID_TAG_FIRST_TIER;
 import static seedu.mycrm.testutil.Assert.assertThrows;
 import static seedu.mycrm.testutil.TypicalContacts.ALICE;
 import static seedu.mycrm.testutil.TypicalContacts.BOB;
@@ -33,7 +33,7 @@ public class ContactTest {
 
         // same name, all other attributes different -> returns true
         Contact editedAlice = new ContactBuilder(ALICE).withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB)
-                .withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_HUSBAND).build();
+                .withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_FIRST_TIER).build();
         assertTrue(ALICE.isSameContact(editedAlice));
 
         // different name, all other attributes same -> returns false
@@ -85,7 +85,7 @@ public class ContactTest {
         assertFalse(ALICE.equals(editedAlice));
 
         // different tags -> returns false
-        editedAlice = new ContactBuilder(ALICE).withTags(VALID_TAG_HUSBAND).build();
+        editedAlice = new ContactBuilder(ALICE).withTags(VALID_TAG_FIRST_TIER).build();
         assertFalse(ALICE.equals(editedAlice));
     }
 }

--- a/src/test/java/seedu/mycrm/model/contact/UniqueContactListTest.java
+++ b/src/test/java/seedu/mycrm/model/contact/UniqueContactListTest.java
@@ -4,7 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.mycrm.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
-import static seedu.mycrm.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
+import static seedu.mycrm.logic.commands.CommandTestUtil.VALID_TAG_FIRST_TIER;
 import static seedu.mycrm.testutil.Assert.assertThrows;
 import static seedu.mycrm.testutil.TypicalContacts.ALICE;
 import static seedu.mycrm.testutil.TypicalContacts.BOB;
@@ -42,7 +42,7 @@ public class UniqueContactListTest {
     @Test
     public void contains_contactWithSameIdentityFieldsInList_returnsTrue() {
         uniqueContactList.add(ALICE);
-        Contact editedAlice = new ContactBuilder(ALICE).withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_HUSBAND)
+        Contact editedAlice = new ContactBuilder(ALICE).withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_FIRST_TIER)
                 .build();
         assertTrue(uniqueContactList.contains(editedAlice));
     }
@@ -85,7 +85,7 @@ public class UniqueContactListTest {
     @Test
     public void setContact_editedContactHasSameIdentity_success() {
         uniqueContactList.add(ALICE);
-        Contact editedAlice = new ContactBuilder(ALICE).withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_HUSBAND)
+        Contact editedAlice = new ContactBuilder(ALICE).withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_FIRST_TIER)
                 .build();
         uniqueContactList.setContact(ALICE, editedAlice);
         UniqueContactList expectedUniqueContactList = new UniqueContactList();

--- a/src/test/java/seedu/mycrm/testutil/ContactBuilder.java
+++ b/src/test/java/seedu/mycrm/testutil/ContactBuilder.java
@@ -69,7 +69,11 @@ public class ContactBuilder {
      * Sets the {@code Address} of the {@code Contact} that we are building.
      */
     public ContactBuilder withAddress(String address) {
-        this.address = new Address(address);
+        if (address != null) {
+            this.address = new Address(address);
+        } else {
+            this.address = new Address();
+        }
         return this;
     }
 
@@ -77,7 +81,11 @@ public class ContactBuilder {
      * Sets the {@code Phone} of the {@code Contact} that we are building.
      */
     public ContactBuilder withPhone(String phone) {
-        this.phone = new Phone(phone);
+        if (phone != null) {
+            this.phone = new Phone(phone);
+        } else {
+            this.phone = new Phone();
+        }
         return this;
     }
 
@@ -85,7 +93,11 @@ public class ContactBuilder {
      * Sets the {@code Email} of the {@code Contact} that we are building.
      */
     public ContactBuilder withEmail(String email) {
-        this.email = new Email(email);
+        if (email != null) {
+            this.email = new Email(email);
+        } else {
+            this.email = new Email();
+        }
         return this;
     }
 

--- a/src/test/java/seedu/mycrm/testutil/TypicalContacts.java
+++ b/src/test/java/seedu/mycrm/testutil/TypicalContacts.java
@@ -8,8 +8,8 @@ import static seedu.mycrm.logic.commands.CommandTestUtil.VALID_NAME_AMY;
 import static seedu.mycrm.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.mycrm.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
 import static seedu.mycrm.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
-import static seedu.mycrm.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
-import static seedu.mycrm.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
+import static seedu.mycrm.logic.commands.CommandTestUtil.VALID_TAG_FIRST_TIER;
+import static seedu.mycrm.logic.commands.CommandTestUtil.VALID_TAG_SECOND_TIER;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -50,10 +50,10 @@ public class TypicalContacts {
 
     // Manually added - Contact's details found in {@code CommandTestUtil}
     public static final Contact AMY = new ContactBuilder().withName(VALID_NAME_AMY).withPhone(VALID_PHONE_AMY)
-            .withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY).withTags(VALID_TAG_FRIEND).build();
+            .withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY).withTags(VALID_TAG_SECOND_TIER).build();
     public static final Contact BOB = new ContactBuilder().withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
-            .withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND)
-            .build();
+            .withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_FIRST_TIER,
+                    VALID_TAG_SECOND_TIER).build();
 
     public static final String KEYWORD_MATCHING_MEIER = "Meier"; // A keyword that matches MEIER
 

--- a/src/test/java/seedu/mycrm/testutil/TypicalContacts.java
+++ b/src/test/java/seedu/mycrm/testutil/TypicalContacts.java
@@ -70,6 +70,16 @@ public class TypicalContacts {
         return ab;
     }
 
+    /**
+     * Returns an {@code MyCrm} with one the typical contacts.
+     */
+    public static MyCrm getOneTypicalMyCrm() {
+        MyCrm ab = new MyCrm();
+        Contact contact = getTypicalContacts().get(0);
+        ab.addContact(contact);
+        return ab;
+    }
+
     public static List<Contact> getTypicalContacts() {
         return new ArrayList<>(Arrays.asList(ALICE, BENSON, CARL, DANIEL, ELLE, FIONA, GEORGE));
     }


### PR DESCRIPTION
Add more test cases for contact commands.

* `DeleteContactCommand`: add test cases in the situation of `filteredList`.
* `AddContactCommandParser`: add test cases for more optional fields situations.

Also fix the bug that contact card displays `null` field issue.