### PR TITLE
add test case for deleteContactCommand

### DIFF
--- a/src/test/java/seedu/mycrm/logic/commands/contacts/DeleteContactCommandTest.java
+++ b/src/test/java/seedu/mycrm/logic/commands/contacts/DeleteContactCommandTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.mycrm.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.mycrm.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.mycrm.logic.commands.CommandTestUtil.showContactAtIndex;
+import static seedu.mycrm.testutil.TypicalContacts.getLinkedJobMyCrm;
 import static seedu.mycrm.testutil.TypicalContacts.getOneTypicalMyCrm;
 import static seedu.mycrm.testutil.TypicalContacts.getTypicalMyCrm;
 import static seedu.mycrm.testutil.TypicalIndexes.INDEX_FIRST_CONTACT;
@@ -25,8 +26,9 @@ import seedu.mycrm.model.contact.Contact;
  */
 public class DeleteContactCommandTest {
 
-    private Model modelTypicalContact = new ModelManager(getTypicalMyCrm(), new UserPrefs());
-    private Model modelOneTypicalContact = new ModelManager(getOneTypicalMyCrm(), new UserPrefs());
+    private final Model modelTypicalContact = new ModelManager(getTypicalMyCrm(), new UserPrefs());
+    private final Model modelOneTypicalContact = new ModelManager(getOneTypicalMyCrm(), new UserPrefs());
+    private final Model modelContactLinkedJob = new ModelManager(getLinkedJobMyCrm(), new UserPrefs());
 
     @Test
     public void execute_validIndexUnfilteredList_success() {
@@ -67,7 +69,7 @@ public class DeleteContactCommandTest {
 
     @Test
     public void execute_invalidIndexFilteredList_throwsCommandException() {
-        showContactAtIndex(modelOneTypicalContact, INDEX_FIRST_CONTACT);
+        showContactAtIndex(modelTypicalContact, INDEX_FIRST_CONTACT);
 
         Index outOfBoundIndex = INDEX_SECOND_CONTACT;
         // ensures that outOfBoundIndex is still in bounds of myCrm list
@@ -75,7 +77,14 @@ public class DeleteContactCommandTest {
 
         DeleteContactCommand deleteCommand = new DeleteContactCommand(outOfBoundIndex);
 
-        assertCommandFailure(deleteCommand, modelOneTypicalContact, Messages.MESSAGE_INVALID_CONTACT_DISPLAYED_INDEX);
+        assertCommandFailure(deleteCommand, modelTypicalContact, Messages.MESSAGE_INVALID_CONTACT_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_invalidDeleteContactLinkedToJob_throwsCommandException() {
+        DeleteContactCommand deleteCommand = new DeleteContactCommand(INDEX_FIRST_CONTACT);
+
+        assertCommandFailure(deleteCommand, modelContactLinkedJob, Messages.MESSAGE_INVALID_CONTACT_DELETE_REQUEST);
     }
 
     @Test

--- a/src/test/java/seedu/mycrm/logic/commands/contacts/EditContactCommandTest.java
+++ b/src/test/java/seedu/mycrm/logic/commands/contacts/EditContactCommandTest.java
@@ -29,7 +29,7 @@ import seedu.mycrm.testutil.ContactBuilder;
 import seedu.mycrm.testutil.EditContactDescriptorBuilder;
 
 class EditContactCommandTest {
-    private Model model = new ModelManager(getTypicalMyCrm(), new UserPrefs());
+    private final Model model = new ModelManager(getTypicalMyCrm(), new UserPrefs());
 
     @Test
     public void execute_allFieldsSpecifiedUnfilteredList_success() {

--- a/src/test/java/seedu/mycrm/testutil/TypicalContacts.java
+++ b/src/test/java/seedu/mycrm/testutil/TypicalContacts.java
@@ -17,6 +17,7 @@ import java.util.List;
 
 import seedu.mycrm.model.MyCrm;
 import seedu.mycrm.model.contact.Contact;
+import seedu.mycrm.model.job.Job;
 
 /**
  * A utility class containing a list of {@code Contact} objects to be used in tests.
@@ -55,6 +56,15 @@ public class TypicalContacts {
             .withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_FIRST_TIER,
                     VALID_TAG_SECOND_TIER).build();
 
+    // Test when a contact is linked to a job, not allow to delete.
+    public static final Contact BOB_LINKED_JOB = new ContactBuilder()
+            .withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB)
+            .withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_FIRST_TIER,
+                    VALID_TAG_SECOND_TIER).build();
+    public static final Job COMPLETED =
+            new JobBuilder().withClient(BOB_LINKED_JOB).withCompletedDate("13/12/2021")
+                    .withCompletionStatus(true).build();
+
     public static final String KEYWORD_MATCHING_MEIER = "Meier"; // A keyword that matches MEIER
 
     private TypicalContacts() {} // prevents instantiation
@@ -91,6 +101,19 @@ public class TypicalContacts {
         Contact contact = getTypicalContacts().get(0);
         contact.setNotHidden();
         mc.addContact(contact);
+        return mc;
+    }
+
+    /**
+     * Returns an {@code MyCrm} with one typical contact linked to a job.
+     */
+    public static MyCrm getLinkedJobMyCrm() {
+        MyCrm mc = new MyCrm();
+        Contact contact = BOB_LINKED_JOB;
+        Job job = COMPLETED;
+        contact.setNotHidden();
+        mc.addContact(contact);
+        mc.addJob(job);
         return mc;
     }
 


### PR DESCRIPTION
Add a test case when a contact is already linked to a job, `deleteContact INDEX` to this contact is not allowed.